### PR TITLE
Wire up interface for to/from geopandas

### DIFF
--- a/geoarrow-pandas/src/geoarrow/pandas/lib.py
+++ b/geoarrow-pandas/src/geoarrow/pandas/lib.py
@@ -48,6 +48,11 @@ class GeoArrowExtensionScalar(bytes):
         )
         return f'GeoArrowExtensionScalar("{wkt_array[0].as_py()}")'
 
+    def to_shapely(self):
+        from shapely import from_wkb
+
+        return from_wkb(self)
+
     @property
     def wkt(self):
         """The well-known text representation of this feature."""
@@ -477,6 +482,4 @@ class GeoArrowAccessor:
         return tuple(_pd.Series(dim, index=self._obj.index) for dim in point_coords)
 
     def to_geopandas(self):
-        import geopandas
-
-        return geopandas.GeoSeries.from_wkb(self.as_wkb().geoarrow.format_wkb())
+        return _ga.to_geopandas(self._obj)

--- a/geoarrow-pandas/tests/test_geoarrow_pandas.py
+++ b/geoarrow-pandas/tests/test_geoarrow_pandas.py
@@ -244,10 +244,3 @@ def test_accessor_with_crs():
 def test_accessor_with_dimensions():
     ga_series = pd.Series(["POINT (0 1)"]).geoarrow.with_dimensions(ga.Dimensions.XYZ)
     assert ga_series.dtype.pyarrow_dtype.dimensions == ga.Dimensions.XYZ
-
-
-def test_accessor_to_geopandas():
-    series = pd.Series(["POINT (0 1)", "POINT (1 2)"])
-    geoseries = series.geoarrow.to_geopandas()
-    assert len(geoseries) == 2
-    assert geoseries[0].wkt == "POINT (0 1)"

--- a/geoarrow-pandas/tests/test_geoarrow_pandas_geopandas.py
+++ b/geoarrow-pandas/tests/test_geoarrow_pandas_geopandas.py
@@ -1,0 +1,16 @@
+import pytest
+
+import pandas as pd
+import geoarrow.pandas as gapd
+import geoarrow.pyarrow as ga
+
+def test_accessor_to_geopandas():
+    series = pd.Series(["POINT (0 1)", "POINT (1 2)"])
+    extension_series = series.geoarrow.as_geoarrow()
+    assert extension_series[0].as_shapely().wkt == "POINT (0 1)"
+
+def test_accessor_to_geopandas():
+    series = pd.Series(["POINT (0 1)", "POINT (1 2)"])
+    geoseries = series.geoarrow.to_geopandas()
+    assert len(geoseries) == 2
+    assert geoseries[0].wkt == "POINT (0 1)"

--- a/geoarrow-pandas/tests/test_geoarrow_pandas_geopandas.py
+++ b/geoarrow-pandas/tests/test_geoarrow_pandas_geopandas.py
@@ -4,10 +4,10 @@ import pandas as pd
 import geoarrow.pandas as gapd
 import geoarrow.pyarrow as ga
 
-def test_accessor_to_geopandas():
+def test_scalar_to_shapely():
     series = pd.Series(["POINT (0 1)", "POINT (1 2)"])
     extension_series = series.geoarrow.as_geoarrow()
-    assert extension_series[0].as_shapely().wkt == "POINT (0 1)"
+    assert extension_series[0].to_shapely().wkt == "POINT (0 1)"
 
 def test_accessor_to_geopandas():
     series = pd.Series(["POINT (0 1)", "POINT (1 2)"])

--- a/geoarrow-pandas/tests/test_geoarrow_pandas_geopandas.py
+++ b/geoarrow-pandas/tests/test_geoarrow_pandas_geopandas.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytest.importorskip("geopandas")
+
 import pandas as pd
 import geoarrow.pandas as gapd
 import geoarrow.pyarrow as ga

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/__init__.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/__init__.py
@@ -58,6 +58,7 @@ from ._compute import (
     with_geometry_type,
     rechunk,
     point_coords,
+    to_geopandas
 )
 
 

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
@@ -562,3 +562,18 @@ def point_coords(obj, dimensions=None):
         return (pa.chunked_array(dim) for dim in zip(*flattened))
     else:
         return obj.storage.flatten()
+
+
+def to_geopandas(obj):
+    import pandas as pd
+    import geopandas
+
+    # Ideally we will avoid serialization via geobuffers + from_ragged_array()
+    wkb_array_or_chunked = as_wkb(obj)
+
+    # Avoids copy on convert to pandas
+    wkb_pandas = pd.Series(
+        wkb_array_or_chunked, dtype=pd.ArrowDtype(wkb_array_or_chunked.type.storage_type)
+    )
+
+    return geopandas.GeoSeries.from_wkb(wkb_pandas, crs=wkb_array_or_chunked.type.crs)

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
@@ -565,6 +565,14 @@ def point_coords(obj, dimensions=None):
 
 
 def to_geopandas(obj):
+    """Extract point coordinates into separate arrays or chunked arrays.
+
+    >>> import geoarrow.pyarrow as ga
+    >>> array = ga.as_geoarrow(["POINT (0 1)"])
+    >>> ga.to_geopandas(array)
+    0    POINT (0.00000 1.00000)
+    dtype: geometry
+    """
     import pandas as pd
     import geopandas
 

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
@@ -5,6 +5,14 @@ from geoarrow.pyarrow._type import VectorType
 
 class VectorScalar(pa.ExtensionScalar):
     def to_shapely(self):
+        """
+        Convert an array item to a shapely geometry
+
+        >>> import geoarrow.pyarrow as ga
+        >>> array = ga.array(["POINT (30 10)"])
+        >>> array[0].to_shapely()
+        <POINT (30 10)>
+        """
         raise NotImplementedError()
 
 

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
@@ -4,7 +4,22 @@ from geoarrow.pyarrow._type import VectorType
 
 
 class VectorScalar(pa.ExtensionScalar):
-    pass
+    def to_shapely(self):
+        raise NotImplementedError()
+
+
+class WktScalar(pa.ExtensionScalar):
+    def to_shapely(self):
+        from shapely import from_wkt
+
+        return from_wkt(self.value.as_py())
+
+
+class WkbScalar(pa.ExtensionScalar):
+    def to_shapely(self):
+        from shapely import from_wkb
+
+        return from_wkb(self.value.as_py())
 
 
 class PointScalar(VectorScalar):
@@ -33,9 +48,9 @@ class MultiPolygonScalar(VectorScalar):
 
 def scalar_cls_from_name(name):
     if name == "geoarrow.wkb":
-        return VectorScalar
+        return WkbScalar
     elif name == "geoarrow.wkt":
-        return VectorScalar
+        return WktScalar
     elif name == "geoarrow.point":
         return PointScalar
     elif name == "geoarrow.linestring":

--- a/geoarrow-pyarrow/tests/test_geopandas.py
+++ b/geoarrow-pyarrow/tests/test_geopandas.py
@@ -1,0 +1,31 @@
+import pytest
+
+geopandas = pytest.importorskip("geopandas")
+
+import geoarrow.pyarrow as ga
+
+
+def test_scalar_to_shapely():
+    array = ga.array(["POINT (30 10)"])
+    assert array[0].to_shapely().wkt == "POINT (30 10)"
+
+    wkb_item = b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x3e\x40\x00\x00\x00\x00\x00\x00\x24\x40"
+    array = ga.array([wkb_item])
+    assert array[0].to_shapely().wkt == "POINT (30 10)"
+
+
+def test_to_geopandas():
+    array = ga.array(["POINT (30 10)"])
+    geoseries = ga.to_geopandas(array)
+    assert isinstance(geoseries, geopandas.GeoSeries)
+    assert len(geoseries) == 1
+    assert geoseries.to_wkt()[0] == "POINT (30 10)"
+
+
+def test_to_geopandas_with_crs():
+    array = ga.with_crs(ga.array(["POINT (30 10)"]), "OGC:CRS84")
+    geoseries = ga.to_geopandas(array)
+    assert isinstance(geoseries, geopandas.GeoSeries)
+    assert len(geoseries) == 1
+    assert geoseries.to_wkt()[0] == "POINT (30 10)"
+    assert geoseries.crs.to_authority() == ("OGC", "CRS84")

--- a/geoarrow-pyarrow/tests/test_pyarrow.py
+++ b/geoarrow-pyarrow/tests/test_pyarrow.py
@@ -116,13 +116,11 @@ def test_array():
     array = ga.array(["POINT (30 10)"])
     assert array.type == ga.wkt()
     assert isinstance(array[0], ga._scalar.WktScalar)
-    assert array[0].to_shapely().wkt == "POINT (30 10)"
 
     wkb_item = b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x3e\x40\x00\x00\x00\x00\x00\x00\x24\x40"
     array = ga.array([wkb_item])
     assert array.type == ga.wkb()
     assert isinstance(array[0], ga._scalar.WkbScalar)
-    assert array[0].to_shapely().wkt == "POINT (30 10)"
 
     with pytest.raises(TypeError):
         ga.array([1])

--- a/geoarrow-pyarrow/tests/test_pyarrow.py
+++ b/geoarrow-pyarrow/tests/test_pyarrow.py
@@ -115,10 +115,14 @@ def test_register_extension_types():
 def test_array():
     array = ga.array(["POINT (30 10)"])
     assert array.type == ga.wkt()
+    assert isinstance(array[0], ga._scalar.WktScalar)
+    assert array[0].to_shapely().wkt == "POINT (30 10)"
 
     wkb_item = b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x3e\x40\x00\x00\x00\x00\x00\x00\x24\x40"
     array = ga.array([wkb_item])
     assert array.type == ga.wkb()
+    assert isinstance(array[0], ga._scalar.WkbScalar)
+    assert array[0].to_shapely().wkt == "POINT (30 10)"
 
     with pytest.raises(TypeError):
         ga.array([1])


### PR DESCRIPTION
Wires up an interface (and leaves future PRs to handle integration with to/from ragged array).

For pandas integration:

```python
import geoarrow.pandas as _
import pandas as pd

df = pd.read_parquet("https://github.com/geoarrow/geoarrow-data/releases/download/latest-dev/ns-water-basin_point.parquet")
df.geometry.geoarrow.to_geopandas()
#> 0     POINT (277022.694 4820886.610)
#> 1     POINT (315701.255 4855051.379)
#> 2     POINT (255728.660 4851022.108)
#> 3     POINT (245206.784 4895609.410)

df.geometry[0].to_shapely()
#> POINT (277022.6936181751 4820886.609673489)
```

For pyarrow integration:

```python
import geoarrow.pyarrow as ga

array = ga.array(["POINT (30 10)"])
ga.to_geopandas(array)
#> 0    POINT (30.00000 10.00000)
#> dtype: geometry
array[0].to_shapely()
#> <POINT (30 10)>
```