### PR TITLE
chore: Remove outdated array methods

### DIFF
--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
@@ -4,8 +4,6 @@ from geoarrow.c import lib
 
 from geoarrow.pyarrow._kernel import Kernel
 from geoarrow.pyarrow._type import (
-    WktType,
-    WkbType,
     VectorType,
     wkb,
     wkt,
@@ -26,35 +24,6 @@ class VectorArray(pa.ExtensionArray):
         array_view = lib.CArrayView(carray, cschema)
         buffers = array_view.buffers()
         return [np.array(b) if b is not None else None for b in buffers]
-
-    def as_wkt(self):
-        if self.type.extension_name == "geoarrow.wkt":
-            return self
-        kernel = Kernel.as_wkt(self.type)
-        return kernel.push(self)
-
-    def as_wkb(self):
-        if self.type.extension_name == "geoarrow.wkb":
-            return self
-        kernel = Kernel.as_wkb(self.type)
-        return kernel.push(self)
-
-    def as_geoarrow(self, type_to=None):
-        if type_to is None:
-            raise NotImplementedError("Auto-detection of best geoarrow type")
-
-        if isinstance(type_to, WktType):
-            return self.as_wkt()
-        elif isinstance(type_to, WkbType):
-            return self.as_wkb()
-        elif not isinstance(type_to, VectorType):
-            raise TypeError("type_to must inherit from VectorType")
-
-        if self.type._type.id == type_to._type.id:
-            return self
-
-        kernel = Kernel.as_geoarrow(self.type, type_to._type.id)
-        return kernel.push(self)
 
     def __repr__(self):
         n_values_to_show = 10

--- a/geoarrow-pyarrow/tests/test_compute.py
+++ b/geoarrow-pyarrow/tests/test_compute.py
@@ -65,7 +65,7 @@ def test_parse_all():
     with pytest.raises(lib.GeoArrowCException):
         _compute.parse_all(["not valid wkt"])
 
-    geoarrow_array = ga.array(["POINT (0 1)"]).as_geoarrow(ga.point())
+    geoarrow_array = ga.as_geoarrow(["POINT (0 1)"])
     assert _compute.parse_all(geoarrow_array) is None
 
 
@@ -73,14 +73,14 @@ def test_as_wkt():
     wkt_array = ga.array(["POINT (0 1)"])
     assert _compute.as_wkt(wkt_array) is wkt_array
 
-    assert _compute.as_wkt(wkt_array.as_wkb()).storage == wkt_array.storage
+    assert _compute.as_wkt(ga.as_wkb(wkt_array)).storage == wkt_array.storage
 
 
 def test_as_wkb():
-    wkb_array = ga.array(["POINT (0 1)"]).as_wkb()
+    wkb_array = ga.as_wkb(["POINT (0 1)"])
     assert _compute.as_wkb(wkb_array) is wkb_array
 
-    assert _compute.as_wkb(wkb_array.as_wkt()).storage == wkb_array.storage
+    assert _compute.as_wkb(ga.as_wkb(wkb_array)).storage == wkb_array.storage
 
 
 def test_format_wkt():
@@ -91,7 +91,7 @@ def test_format_wkt():
 
 
 def test_unique_geometry_types():
-    ga_array = ga.array(pa.array([], type=pa.utf8())).as_geoarrow(ga.point())
+    ga_array = ga.as_geoarrow(pa.array([], type=pa.utf8()), ga.point())
     out = _compute.unique_geometry_types(ga_array).flatten()
     assert out[0] == pa.array([ga.GeometryType.POINT], type=pa.int32())
     assert out[1] == pa.array([ga.Dimensions.XY], type=pa.int32())
@@ -132,7 +132,7 @@ def test_infer_type_common():
     common = _compute.infer_type_common(empty)
     assert common == pa.null()
 
-    already_geoarrow = ga.array(["POINT (0 1)"]).as_geoarrow(ga.point())
+    already_geoarrow = ga.as_geoarrow(["POINT (0 1)"])
     common = _compute.infer_type_common(already_geoarrow)
     assert common.id == already_geoarrow.type.id
     common_interleaved = _compute.infer_type_common(


### PR DESCRIPTION
..the existing extension array methods were outdated and have been superceeded by `_compute` functions that work on more things than just an array. Because pyarrow's `ChunkedArray` does not have type-specific methods, I think we want to encourage (e.g.) `geoarrow.pyarrow.as_wkt(something)` rather than `something.as_wkt()` because it's pretty easy to get `something` that is a `ChunkedArray` (e.g., by using `__arrow_array__` protocol or `pyarrow.array()`, both of which might return either).