### PR TITLE
feat: Add `read_pyogrio_table()`

### DIFF
--- a/docs/source/pyarrow.rst
+++ b/docs/source/pyarrow.rst
@@ -99,6 +99,14 @@ geoarrow-pyarrow
     .. autoclass:: MultiPolygonType
         :members:
 
+IO helpers
+--------------------
+
+.. automodule:: geoarrow.pyarrow.io
+
+    .. autofunction:: read_pyogrio_table
+
+
 Dataset constructors
 --------------------
 

--- a/geoarrow-pyarrow/pyproject.toml
+++ b/geoarrow-pyarrow/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.8"
 dependencies = ["geoarrow-c", "pyarrow"]
 
 [project.optional-dependencies]
-test = ["pytest", "pandas", "numpy", "geopandas"]
+test = ["pytest", "pandas", "numpy", "geopandas", "pyogrio", "pyproj"]
 
 [project.urls]
 homepage = "https://geoarrow.org"

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
@@ -1,7 +1,49 @@
+"""GeoArrow IO helpers
+
+A module wrapping IO functionality from external libraries to simplify
+testing and documenting the GeoArrow format and encodings.
+
+>>> from geoarrow.pyarrow import io
+"""
+
 import geoarrow.pyarrow as _ga
 
 
-def read_pyogrio_table(*args, **kwargs):
+def read_pyogrio_table(
+    *args,
+    geoarrow_type=None,
+    geoarrow_coord_type=None,
+    geoarrow_promote_multi=False,
+    **kwargs
+):
+    """Read a file using GDAL/OGR
+
+    Reads a file as a ``pyarrow.Table`` using ``pyogrio.raw.read_arrow()``,
+    applying :func:`geoarrow.pyarrow.as_geoarrow` to the geometry column.
+    This aggressively parses the geometry column into a geoarrow-native
+    encoding: to prevent this, use ``geoarrow_type=geoarrow.pyarrow.wkb()``.
+
+    >>> from geoarrow.pyarrow import io
+    >>> import tempfile
+    >>> import geopandas
+    >>> import os
+    >>> with tempfile.TemporaryDirectory() as tmpdir:
+    ...     temp_gpkg = os.path.join(tmpdir, "test.gpkg")
+    ...     geopandas.GeoDataFrame(
+    ...         geometry=geopandas.GeoSeries.from_wkt(["POINT (0 1)"],
+    ...         crs="OGC:CRS84")
+    ...     ).to_file(temp_gpkg)
+    ...     io.read_pyogrio_table(temp_gpkg)
+    pyarrow.Table
+    geom: extension<geoarrow.point<PointType>>
+    ----
+    geom: [  -- is_valid: all not null
+      -- child 0 type: double
+    [0]
+      -- child 1 type: double
+    [1]]
+
+    """
     from pyogrio.raw import read_arrow
     import pyproj
 
@@ -12,16 +54,20 @@ def read_pyogrio_table(*args, **kwargs):
 
     # Create the geoarrow-enabled geometry column with a crs attribute
     prj = pyproj.CRS(meta["crs"])
-    geoarrow_type = _ga.wkb().with_crs(prj.to_json())
-    geometry = geoarrow_type.wrap_array(table.column(geometry_name))
 
-    # Apply CRS to geometry column. This doesn't scale to multiple geometry
+    # Apply geoarrow type to geometry column. This doesn't scale to multiple geometry
     # columns, but it's unclear if other columns would share the same CRS.
     for i, nm in enumerate(table.column_names):
         if nm == geometry_name:
             geometry = table.column(i)
-            geometry = geoarrow_type.wrap_array(geometry)
-            table = table.set_column(i, nm, geometry)
+            geometry = _ga.wkb().wrap_array(geometry)
+            geometry = _ga.as_geoarrow(
+                geometry,
+                type=geoarrow_type,
+                coord_type=geoarrow_coord_type,
+                promote_multi=geoarrow_promote_multi,
+            )
+            table = table.set_column(i, nm, _ga.with_crs(geometry, prj.to_json()))
             break
 
     return table

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
@@ -6,18 +6,22 @@ def read_pyogrio_table(*args, **kwargs):
     import pyproj
 
     meta, table = read_arrow(*args, **kwargs)
-    # Maybe not always true? meta["geometry_name"] is occasionally empty ""
+
+    # Maybe not always true? meta["geometry_name"] is occasionally `""`
     geometry_name = meta["geometry_name"] if meta["geometry_name"] else "wkb_geometry"
 
-    # Create the geoarrow-enabled geometry column
+    # Create the geoarrow-enabled geometry column with a crs attribute
     prj = pyproj.CRS(meta["crs"])
-    geometry_type = _ga.wkb().with_crs(prj.to_json())
-    geometry = geometry_type.wrap_array(table.column(geometry_name))
+    geoarrow_type = _ga.wkb().with_crs(prj.to_json())
+    geometry = geoarrow_type.wrap_array(table.column(geometry_name))
 
-    # Move geometry column to the end and name it 'geometry'
+    # Apply CRS to geometry column. This doesn't scale to multiple geometry
+    # columns, but it's unclear if other columns would share the same CRS.
     for i, nm in enumerate(table.column_names):
         if nm == geometry_name:
-            table = table.remove_column(i)
+            geometry = table.column(i)
+            geometry = geoarrow_type.wrap_array(geometry)
+            table = table.set_column(i, nm, geometry)
             break
 
-    return table.append_column("geometry", geometry)
+    return table

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
@@ -1,0 +1,23 @@
+import geoarrow.pyarrow as _ga
+
+
+def read_pyogrio_table(*args, **kwargs):
+    from pyogrio.raw import read_arrow
+    import pyproj
+
+    meta, table = read_arrow(*args, **kwargs)
+    # Maybe not always true? meta["geometry_name"] is occasionally empty ""
+    geometry_name = meta["geometry_name"] if meta["geometry_name"] else "wkb_geometry"
+
+    # Create the geoarrow-enabled geometry column
+    prj = pyproj.CRS(meta["crs"])
+    geometry_type = _ga.wkb().with_crs(prj.to_json())
+    geometry = geometry_type.wrap_array(table.column(geometry_name))
+
+    # Move geometry column to the end and name it 'geometry'
+    for i, nm in enumerate(table.column_names):
+        if nm == geometry_name:
+            table = table.remove_column(i)
+            break
+
+    return table.append_column("geometry", geometry)

--- a/geoarrow-pyarrow/tests/test_io.py
+++ b/geoarrow-pyarrow/tests/test_io.py
@@ -1,0 +1,23 @@
+import pytest
+import tempfile
+import os
+
+pyogrio = pytest.importorskip("pyogrio")
+geopandas = pytest.importorskip("geopandas")
+
+import geoarrow.pyarrow as ga
+from geoarrow.pyarrow import io
+
+
+def test_readpyogrio_table():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        temp_gpkg = os.path.join(tmpdir, "test.gpkg")
+        df = geopandas.GeoDataFrame(
+            geometry=geopandas.GeoSeries.from_wkt(["POINT (0 1)"], crs="OGC:CRS84")
+        )
+        crs_json = df.geometry.crs.to_json()
+        pyogrio.write_dataframe(df, temp_gpkg)
+
+        table = io.read_pyogrio_table(temp_gpkg)
+        assert table.column("geom").type == ga.wkb().with_crs(crs_json)
+        assert ga.format_wkt(table.column("geom")).to_pylist() == ["POINT (0 1)"]

--- a/geoarrow-pyarrow/tests/test_io.py
+++ b/geoarrow-pyarrow/tests/test_io.py
@@ -18,6 +18,26 @@ def test_readpyogrio_table():
         crs_json = df.geometry.crs.to_json()
         pyogrio.write_dataframe(df, temp_gpkg)
 
+        # With auto:
         table = io.read_pyogrio_table(temp_gpkg)
+        assert table.column("geom").type == ga.point().with_crs(crs_json)
+        assert ga.format_wkt(table.column("geom")).to_pylist() == ["POINT (0 1)"]
+
+        # Explicit coord type:
+        table = io.read_pyogrio_table(
+            temp_gpkg, geoarrow_coord_type=ga.CoordType.INTERLEAVED
+        )
+        assert table.column("geom").type == ga.point().with_coord_type(
+            ga.CoordType.INTERLEAVED
+        ).with_crs(crs_json)
+        assert ga.format_wkt(table.column("geom")).to_pylist() == ["POINT (0 1)"]
+
+        # Explicit promote multi:
+        table = io.read_pyogrio_table(temp_gpkg, geoarrow_promote_multi=True)
+        assert table.column("geom").type == ga.multipoint().with_crs(crs_json)
+        assert ga.format_wkt(table.column("geom")).to_pylist() == ["MULTIPOINT (0 1)"]
+
+        # Explicit type:
+        table = io.read_pyogrio_table(temp_gpkg, geoarrow_type=ga.wkb())
         assert table.column("geom").type == ga.wkb().with_crs(crs_json)
         assert ga.format_wkt(table.column("geom")).to_pylist() == ["POINT (0 1)"]

--- a/geoarrow-pyarrow/tests/test_io.py
+++ b/geoarrow-pyarrow/tests/test_io.py
@@ -18,26 +18,6 @@ def test_readpyogrio_table():
         crs_json = df.geometry.crs.to_json()
         pyogrio.write_dataframe(df, temp_gpkg)
 
-        # With auto:
         table = io.read_pyogrio_table(temp_gpkg)
-        assert table.column("geom").type == ga.point().with_crs(crs_json)
-        assert ga.format_wkt(table.column("geom")).to_pylist() == ["POINT (0 1)"]
-
-        # Explicit coord type:
-        table = io.read_pyogrio_table(
-            temp_gpkg, geoarrow_coord_type=ga.CoordType.INTERLEAVED
-        )
-        assert table.column("geom").type == ga.point().with_coord_type(
-            ga.CoordType.INTERLEAVED
-        ).with_crs(crs_json)
-        assert ga.format_wkt(table.column("geom")).to_pylist() == ["POINT (0 1)"]
-
-        # Explicit promote multi:
-        table = io.read_pyogrio_table(temp_gpkg, geoarrow_promote_multi=True)
-        assert table.column("geom").type == ga.multipoint().with_crs(crs_json)
-        assert ga.format_wkt(table.column("geom")).to_pylist() == ["MULTIPOINT (0 1)"]
-
-        # Explicit type:
-        table = io.read_pyogrio_table(temp_gpkg, geoarrow_type=ga.wkb())
         assert table.column("geom").type == ga.wkb().with_crs(crs_json)
         assert ga.format_wkt(table.column("geom")).to_pylist() == ["POINT (0 1)"]


### PR DESCRIPTION
...lifted from https://github.com/geoarrow/geoarrow-data/blob/main/ogr_to_geoarrow.py that was used to make example data. This is useful because you can get pretty much *any* data as geoarrow with pretty minimal code. It can be faster than reading through GeoPandas (but that's not the primary motivation):

```python
from geoarrow.pyarrow import io

tab = io.read_pyogrio_table("https://raw.githubusercontent.com/geoarrow/geoarrow-data/v0.1.0/example/example-linestring.gpkg")
tab.column("geom").chunk(0).geobuffers()
#> [None,
#>  array([0, 3, 3, 3], dtype=int32),
#>  array([30., 10., 40.]),
#>  array([10., 30., 40.])]
```