### PR TITLE
perf: Remove validation from `wrap_array()`

### DIFF
--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
@@ -117,7 +117,7 @@ if VectorType._array_cls_from_name is None:
     VectorType._array_cls_from_name = array_cls_from_name
 
 
-def array(obj, type_=None, *args, validate=True, **kwargs) -> VectorArray:
+def array(obj, type_=None, *args, **kwargs) -> VectorArray:
     """Attempt to create an Array or ChunkedArray with a geoarrow extension type
     from ``obj``. This constructor attempts to perform the fewest transformations
     possible (i.e., WKB is left as WKB, WKT is left as WKT), whereas
@@ -156,13 +156,13 @@ def array(obj, type_=None, *args, validate=True, **kwargs) -> VectorArray:
         if isinstance(arr.type, VectorType):
             return arr
         elif arr.type == pa.utf8():
-            return wkt().wrap_array(arr, validate=validate)
+            return wkt().wrap_array(arr)
         elif arr.type == pa.large_utf8():
-            return large_wkt().wrap_array(arr, validate=validate)
+            return large_wkt().wrap_array(arr)
         elif arr.type == pa.binary():
-            return wkb().wrap_array(arr, validate=validate)
+            return wkb().wrap_array(arr)
         elif arr.type == pa.large_binary():
-            return large_wkb().wrap_array(arr, validate=validate)
+            return large_wkb().wrap_array(arr)
         else:
             raise TypeError(
                 f"Can't create geoarrow.array from Arrow array of type {type_}"
@@ -177,7 +177,7 @@ def array(obj, type_=None, *args, validate=True, **kwargs) -> VectorArray:
 
     if type_is_geoarrow and type_is_wkb_or_wkt:
         arr = arr.cast(type_.storage_type)
-        return type_.wrap_array(arr, validate=validate)
+        return type_.wrap_array(arr)
 
     # Eventually we will be able to handle more types (e.g., parse wkt or wkb
     # into a geoarrow type)

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
@@ -13,7 +13,7 @@ def obj_as_array_or_chunked(obj_in):
     ) and isinstance(obj_in.type, _type.VectorType):
         return obj_in
     else:
-        return array(obj_in, validate=False)
+        return array(obj_in)
 
 
 def ensure_storage(obj):

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_kernel.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_kernel.py
@@ -118,8 +118,3 @@ class Kernel:
             bytes += v.encode("UTF-8")
 
         return bytes
-
-
-# Inject _make_validate_kernel exactly once to avoid circular import
-if VectorType._make_validate_kernel is None:
-    VectorType._make_validate_kernel = Kernel.visit_void_agg

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_type.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_type.py
@@ -13,7 +13,6 @@ class VectorType(pa.ExtensionType):
     # use this module directly (import geoarrow.pyarrow first).
     _array_cls_from_name = None
     _scalar_cls_from_name = None
-    _make_validate_kernel = None
 
     def __init__(self, c_vector_type):
         if not isinstance(c_vector_type, lib.CVectorType):
@@ -68,15 +67,6 @@ class VectorType(pa.ExtensionType):
         return cls.__arrow_ext_deserialize__(
             storage_type, c_vector_type.extension_metadata
         )
-
-    def wrap_array(self, obj, validate=False):
-        out = super().wrap_array(obj)
-        if validate:
-            validator = VectorType._make_validate_kernel(self)
-            validator.push(out)
-            validator.finish()
-
-        return out
 
     def __arrow_ext_class__(self):
         return VectorType._array_cls_from_name(self.extension_name)
@@ -276,9 +266,6 @@ class WkbType(VectorType):
 
     _extension_name = "geoarrow.wkb"
 
-    def wrap_array(self, obj, validate=True):
-        return super().wrap_array(obj, validate=validate)
-
 
 class WktType(VectorType):
     """Extension type whose storage is a utf8 or large utf8 array of
@@ -286,9 +273,6 @@ class WktType(VectorType):
     """
 
     _extension_name = "geoarrow.wkt"
-
-    def wrap_array(self, obj, validate=True):
-        return super().wrap_array(obj, validate=validate)
 
 
 class PointType(VectorType):

--- a/geoarrow-pyarrow/tests/test_pyarrow.py
+++ b/geoarrow-pyarrow/tests/test_pyarrow.py
@@ -129,8 +129,7 @@ def test_array():
     assert array.type == ga.wkt()
     assert array.type.storage_type == pa.utf8()
 
-    # Validation not yet supported for large types
-    array = ga.array(["POINT (30 10)"], ga.large_wkt(), validate=False)
+    array = ga.array(["POINT (30 10)"], ga.large_wkt())
     assert array.type == ga.large_wkt()
     assert array.type.storage_type == pa.large_utf8()
 
@@ -138,8 +137,7 @@ def test_array():
     assert array.type == ga.wkb()
     assert array.type.storage_type == pa.binary()
 
-    # Validation not yet supported for large types
-    array = ga.array([wkb_item], ga.large_wkb(), validate=False)
+    array = ga.array([wkb_item], ga.large_wkb())
     assert array.type == ga.large_wkb()
     assert array.type.storage_type == pa.large_binary()
 
@@ -160,7 +158,7 @@ def test_array_repr():
     array_repr = repr(array)
     assert "...>" in array_repr
 
-    array = ga.array(["THIS IS TOTALLY INVALID WKT"], validate=False)
+    array = ga.array(["THIS IS TOTALLY INVALID WKT"])
     array_repr = repr(array)
     assert array_repr.startswith("VectorArray")
     assert "* 1 or more display values failed to parse" in array_repr
@@ -259,9 +257,7 @@ def test_kernel_visit_void():
     assert out.type == pa.null()
     assert len(out) == 1
 
-    array = ga.array(
-        ["POINT (30 10)", "NOT VALID WKT AT ALL"], ga.wkt(), validate=False
-    )
+    array = ga.array(["POINT (30 10)", "NOT VALID WKT AT ALL"], ga.wkt())
     kernel = ga.Kernel.visit_void_agg(array.type)
     with pytest.raises(lib.GeoArrowCException):
         kernel.push(array)


### PR DESCRIPTION
This resulted in some unexpected performance characteristics and was not all that useful (since you could still have geometrically invalid data that happened to parse with `validate=True`). Because it was the default, it was pretty easy to get terrible performance and not know why (e.g., with `geoarrow.pyarrow.io.read_pyogrio_table()`).