### PR TITLE
Rename `VectorType` to `GeometryExtensionType`

### DIFF
--- a/docs/source/pyarrow.rst
+++ b/docs/source/pyarrow.rst
@@ -72,7 +72,7 @@ geoarrow-pyarrow
     Class Reference
     ---------------
 
-    .. autoclass:: VectorType
+    .. autoclass:: GeometryExtensionType
         :members:
 
     .. autoclass:: WkbType

--- a/geoarrow-pandas/src/geoarrow/pandas/lib.py
+++ b/geoarrow-pandas/src/geoarrow/pandas/lib.py
@@ -202,7 +202,7 @@ class GeoArrowExtensionArray(_pd.api.extensions.ExtensionArray):
             return items[0]
 
         types = [item._data.type for item in to_concat]
-        common_type = _ga.vector_type_common(types)
+        common_type = _ga.geometry_type_common(types)
 
         chunks = []
         for item in to_concat:
@@ -334,7 +334,7 @@ class GeoArrowExtensionDtype(_pd.api.extensions.ExtensionDtype):
         elif params["type"] == "wkt":
             base_type = _ga.wkt()
         else:
-            base_type = _ga.vector_type(geometry_type, dims, coord_type)
+            base_type = _ga.extension_type(geometry_type, dims, coord_type)
 
         try:
             if params["metadata"]:

--- a/geoarrow-pandas/src/geoarrow/pandas/lib.py
+++ b/geoarrow-pandas/src/geoarrow/pandas/lib.py
@@ -78,10 +78,11 @@ class GeoArrowExtensionArray(_pd.api.extensions.ExtensionArray):
     or ``pyarrow.ChunkedArray`` with an extension type. Most users will
     not instantiate this class directly.
     """
+
     def __init__(self, obj, type=None):
         if type is not None:
             self._dtype = GeoArrowExtensionDtype(type)
-            arrow_type = _ga.VectorType._from_ctype(self._dtype._parent)
+            arrow_type = _ga.GeometryExtensionType._from_ctype(self._dtype._parent)
             self._data = _ga.array(obj, arrow_type)
         else:
             self._data = _ga.array(obj)
@@ -256,7 +257,7 @@ class GeoArrowExtensionDtype(_pd.api.extensions.ExtensionDtype):
     )
 
     def __init__(self, parent):
-        if isinstance(parent, _ga.VectorType):
+        if isinstance(parent, _ga.GeometryExtensionType):
             self._parent = parent._type
         elif isinstance(parent, lib.CVectorType):
             self._parent = parent
@@ -270,7 +271,7 @@ class GeoArrowExtensionDtype(_pd.api.extensions.ExtensionDtype):
 
     @property
     def pyarrow_dtype(self):
-        return _ga.VectorType._from_ctype(self._parent)
+        return _ga.GeometryExtensionType._from_ctype(self._parent)
 
     @property
     def type(self):
@@ -429,24 +430,20 @@ class GeoArrowAccessor:
         return isinstance(self._obj.dtype, GeoArrowExtensionDtype)
 
     def parse_all(self):
-        """See :func:`geoarrow.pyarrow.parse_all`
-        """
+        """See :func:`geoarrow.pyarrow.parse_all`"""
         _ga.parse_all(self._obj)
         return self._obj
 
     def as_wkt(self):
-        """See :func:`geoarrow.pyarrow.as_wkt`
-        """
+        """See :func:`geoarrow.pyarrow.as_wkt`"""
         return self._wrap_series(_ga.as_wkt(self._obj))
 
     def as_wkb(self):
-        """See :func:`geoarrow.pyarrow.as_wkb`
-        """
+        """See :func:`geoarrow.pyarrow.as_wkb`"""
         return self._wrap_series(_ga.as_wkb(self._obj))
 
     def format_wkt(self, precision=None, max_element_size_bytes=None):
-        """See :func:`geoarrow.pyarrow.format_wkt`
-        """
+        """See :func:`geoarrow.pyarrow.format_wkt`"""
         if not self._obj_is_geoarrow():
             raise TypeError("Can't format_wkt() a non-geoarrow Series")
 
@@ -462,8 +459,7 @@ class GeoArrowAccessor:
         )
 
     def format_wkb(self):
-        """See :func:`geoarrow.pyarrow.as_wkb`
-        """
+        """See :func:`geoarrow.pyarrow.as_wkb`"""
         if not self._obj_is_geoarrow():
             raise TypeError("Can't format_wkb() a non-geoarrow Series")
 
@@ -482,14 +478,12 @@ class GeoArrowAccessor:
         )
 
     def as_geoarrow(self, type=None, coord_type=None):
-        """See :func:`geoarrow.pyarrow.as_geoarrow`
-        """
+        """See :func:`geoarrow.pyarrow.as_geoarrow`"""
         array_or_chunked = _ga.as_geoarrow(self._obj, type=type, coord_type=coord_type)
         return self._wrap_series(array_or_chunked)
 
     def bounds(self):
-        """See :func:`geoarrow.pyarrow.box`
-        """
+        """See :func:`geoarrow.pyarrow.box`"""
         array_or_chunked = _ga.box(self._obj)
         if isinstance(array_or_chunked, _pa.ChunkedArray):
             flattened = [chunk.flatten() for chunk in array_or_chunked.chunks]
@@ -510,43 +504,35 @@ class GeoArrowAccessor:
         )
 
     def total_bounds(self):
-        """See :func:`geoarrow.pyarrow.box_agg`
-        """
+        """See :func:`geoarrow.pyarrow.box_agg`"""
         struct_scalar1 = _ga.box_agg(self._obj)
         return _pd.DataFrame({k: [v] for k, v in struct_scalar1.as_py().items()})
 
     def with_coord_type(self, coord_type):
-        """See :func:`geoarrow.pyarrow.with_coord_type`
-        """
+        """See :func:`geoarrow.pyarrow.with_coord_type`"""
         return self._wrap_series(_ga.with_coord_type(self._obj, coord_type))
 
     def with_edge_type(self, edge_type):
-        """See :func:`geoarrow.pyarrow.with_edge_type`
-        """
+        """See :func:`geoarrow.pyarrow.with_edge_type`"""
         return self._wrap_series(_ga.with_edge_type(self._obj, edge_type))
 
     def with_crs(self, crs, crs_type=None):
-        """See :func:`geoarrow.pyarrow.with_crs`
-        """
+        """See :func:`geoarrow.pyarrow.with_crs`"""
         return self._wrap_series(_ga.with_crs(self._obj, crs=crs, crs_type=crs_type))
 
     def with_dimensions(self, dimensions):
-        """See :func:`geoarrow.pyarrow.with_dimensions`
-        """
+        """See :func:`geoarrow.pyarrow.with_dimensions`"""
         return self._wrap_series(_ga.with_dimensions(self._obj, dimensions))
 
     def with_geometry_type(self, geometry_type):
-        """See :func:`geoarrow.pyarrow.with_geometry_type`
-        """
+        """See :func:`geoarrow.pyarrow.with_geometry_type`"""
         return self.with_geometry_type(_ga.with_coord_type(self._obj, geometry_type))
 
     def point_coords(self, dimensions=None):
-        """See :func:`geoarrow.pyarrow.point_coords`
-        """
+        """See :func:`geoarrow.pyarrow.point_coords`"""
         point_coords = _ga.point_coords(_ga.with_coord_type(self._obj, dimensions))
         return tuple(_pd.Series(dim, index=self._obj.index) for dim in point_coords)
 
     def to_geopandas(self):
-        """See :func:`geoarrow.pyarrow.to_geopandas`
-        """
+        """See :func:`geoarrow.pyarrow.to_geopandas`"""
         return _ga.to_geopandas(self._obj)

--- a/geoarrow-pandas/src/geoarrow/pandas/lib.py
+++ b/geoarrow-pandas/src/geoarrow/pandas/lib.py
@@ -245,7 +245,8 @@ class GeoArrowExtensionDtype(_pd.api.extensions.ExtensionDtype):
 
     The dtype object for geoarrow-encoded arrays that are converted
     to pandas. Use the ``pyarrow_dtype`` property to return the underlying
-    ``VectorType`` (e.g., to query the ``crs`` or ``dimensions``).
+    :class:`geoarrow.pyarrow.GeometryExtensionType` (e.g., to query the
+    ``crs`` or ``dimensions``).
     """
 
     _match = _re.compile(

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/__init__.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/__init__.py
@@ -10,7 +10,7 @@ Examples
 from geoarrow.c.lib import GeometryType, Dimensions, CoordType, EdgeType, CrsType
 
 from geoarrow.pyarrow._type import (
-    VectorType,
+    GeometryExtensionType,
     WktType,
     WkbType,
     PointType,

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/__init__.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/__init__.py
@@ -29,8 +29,8 @@ from geoarrow.pyarrow._type import (
     multipoint,
     multilinestring,
     multipolygon,
-    vector_type,
-    vector_type_common,
+    extension_type,
+    geometry_type_common,
     register_extension_types,
     unregister_extension_types,
 )

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/__init__.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/__init__.py
@@ -41,7 +41,7 @@ from geoarrow.pyarrow._array import array
 
 from geoarrow.pyarrow import _scalar
 
-from ._compute import (
+from geoarrow.pyarrow._compute import (
     parse_all,
     as_wkt,
     as_wkb,

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
@@ -12,7 +12,7 @@ from geoarrow.pyarrow._type import (
 )
 
 
-class VectorArray(pa.ExtensionArray):
+class GeometryExtensionArray(pa.ExtensionArray):
     def geobuffers(self):
         import numpy as np
 
@@ -67,35 +67,35 @@ class VectorArray(pa.ExtensionArray):
         return f"{type_name}:{repr(self.type)}[{len(self)}]\n{items_str}".strip()
 
 
-class PointArray(VectorArray):
+class PointArray(GeometryExtensionArray):
     pass
 
 
-class LinestringArray(VectorArray):
+class LinestringArray(GeometryExtensionArray):
     pass
 
 
-class PolygonArray(VectorArray):
+class PolygonArray(GeometryExtensionArray):
     pass
 
 
-class MultiPointArray(VectorArray):
+class MultiPointArray(GeometryExtensionArray):
     pass
 
 
-class MultiLinestringArray(VectorArray):
+class MultiLinestringArray(GeometryExtensionArray):
     pass
 
 
-class MultiPolygonArray(VectorArray):
+class MultiPolygonArray(GeometryExtensionArray):
     pass
 
 
 def array_cls_from_name(name):
     if name == "geoarrow.wkb":
-        return VectorArray
+        return GeometryExtensionArray
     elif name == "geoarrow.wkt":
-        return VectorArray
+        return GeometryExtensionArray
     elif name == "geoarrow.point":
         return PointArray
     elif name == "geoarrow.linestring":
@@ -117,7 +117,7 @@ if GeometryExtensionType._array_cls_from_name is None:
     GeometryExtensionType._array_cls_from_name = array_cls_from_name
 
 
-def array(obj, type_=None, *args, **kwargs) -> VectorArray:
+def array(obj, type_=None, *args, **kwargs) -> GeometryExtensionArray:
     """Attempt to create an Array or ChunkedArray with a geoarrow extension type
     from ``obj``. This constructor attempts to perform the fewest transformations
     possible (i.e., WKB is left as WKB, WKT is left as WKT), whereas

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
@@ -128,7 +128,7 @@ def array(obj, type_=None, *args, **kwargs) -> GeometryExtensionArray:
 
     >>> import geoarrow.pyarrow as ga
     >>> ga.array(["POINT (0 1)"])
-    VectorArray:WktType(geoarrow.wkt)[1]
+    GeometryExtensionArray:WktType(geoarrow.wkt)[1]
     <POINT (0 1)>
     >>> ga.as_geoarrow(["POINT (0 1)"])
     PointArray:PointType(geoarrow.point)[1]

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
@@ -4,7 +4,7 @@ from geoarrow.c import lib
 
 from geoarrow.pyarrow._kernel import Kernel
 from geoarrow.pyarrow._type import (
-    VectorType,
+    GeometryExtensionType,
     wkb,
     wkt,
     large_wkb,
@@ -113,8 +113,8 @@ def array_cls_from_name(name):
 
 
 # Inject array_cls_from_name exactly once to avoid circular import
-if VectorType._array_cls_from_name is None:
-    VectorType._array_cls_from_name = array_cls_from_name
+if GeometryExtensionType._array_cls_from_name is None:
+    GeometryExtensionType._array_cls_from_name = array_cls_from_name
 
 
 def array(obj, type_=None, *args, **kwargs) -> VectorArray:
@@ -153,7 +153,7 @@ def array(obj, type_=None, *args, **kwargs) -> VectorArray:
 
     # Handle the case where we get to pick the type
     if type_ is None:
-        if isinstance(arr.type, VectorType):
+        if isinstance(arr.type, GeometryExtensionType):
             return arr
         elif arr.type == pa.utf8():
             return wkt().wrap_array(arr)
@@ -172,7 +172,7 @@ def array(obj, type_=None, *args, **kwargs) -> VectorArray:
     if type_ == arr.type:
         return arr
 
-    type_is_geoarrow = isinstance(type_, VectorType)
+    type_is_geoarrow = isinstance(type_, GeometryExtensionType)
     type_is_wkb_or_wkt = type_.extension_name in ("geoarrow.wkt", "geoarrow.wkb")
 
     if type_is_geoarrow and type_is_wkb_or_wkt:

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
@@ -125,7 +125,7 @@ def unique_geometry_types(obj):
 
 
 def infer_type_common(obj, coord_type=None, promote_multi=False):
-    """Infer a common :class:`geoarrow.pyarrow.VectorType` for the
+    """Infer a common :class:`geoarrow.pyarrow.GeometryExtensionType` for the
     geometries in ``obj``, preferring geoarrow-encoded types and falling back
     to well-known binary.
 
@@ -210,7 +210,7 @@ def as_wkt(obj):
     >>> import geoarrow.pyarrow as ga
     >>> points = ga.as_geoarrow(["POINT (0 1)"])
     >>> ga.as_wkt(points)
-    VectorArray:WktType(geoarrow.wkt)[1]
+    GeometryExtensionArray:WktType(geoarrow.wkt)[1]
     <POINT (0 1)>
     """
     return as_geoarrow(obj, _type.wkt())
@@ -222,7 +222,7 @@ def as_wkb(obj):
     >>> import geoarrow.pyarrow as ga
     >>> points = ga.as_geoarrow(["POINT (0 1)"])
     >>> ga.as_wkb(points)
-    VectorArray:WkbType(geoarrow.wkb)[1]
+    GeometryExtensionArray:WkbType(geoarrow.wkb)[1]
     <POINT (0 1)>
     """
     return as_geoarrow(obj, _type.wkb())
@@ -441,7 +441,7 @@ def with_edge_type(obj, edge_type):
 
     >>> import geoarrow.pyarrow as ga
     >>> ga.with_edge_type(["LINESTRING (0 1, 2 3)"], ga.EdgeType.SPHERICAL)
-    VectorArray:WktType(spherical geoarrow.wkt)[1]
+    GeometryExtensionArray:WktType(spherical geoarrow.wkt)[1]
     <LINESTRING (0 1, 2 3)>
     """
     obj = obj_as_array_or_chunked(obj)
@@ -454,7 +454,7 @@ def with_crs(obj, crs, crs_type=None):
 
     >>> import geoarrow.pyarrow as ga
     >>> ga.with_crs(["POINT (0 1)"], "EPSG:1234")
-    VectorArray:WktType(geoarrow.wkt <EPSG:1234>)[1]
+    GeometryExtensionArray:WktType(geoarrow.wkt <EPSG:1234>)[1]
     <POINT (0 1)>
     """
     obj = obj_as_array_or_chunked(obj)

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
@@ -10,7 +10,7 @@ from geoarrow.pyarrow._kernel import Kernel
 def obj_as_array_or_chunked(obj_in):
     if (
         isinstance(obj_in, pa.Array) or isinstance(obj_in, pa.ChunkedArray)
-    ) and isinstance(obj_in.type, _type.VectorType):
+    ) and isinstance(obj_in.type, _type.GeometryExtensionType):
         return obj_in
     else:
         return array(obj_in)

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
@@ -194,7 +194,7 @@ def infer_type_common(obj, coord_type=None, promote_multi=False):
     if promote_multi and geometry_type <= GeometryType.POLYGON:
         geometry_type += 3
 
-    return _type.vector_type(
+    return _type.extension_type(
         geometry_type,
         dimensions,
         coord_type,

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_kernel.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_kernel.py
@@ -3,7 +3,7 @@ import sys
 import pyarrow as pa
 
 from geoarrow.c import lib
-from geoarrow.pyarrow._type import VectorType
+from geoarrow.pyarrow._type import GeometryExtensionType
 
 
 class Kernel:
@@ -22,7 +22,7 @@ class Kernel:
         options = Kernel._pack_options(kwargs)
 
         type_out_schema = self._kernel.start(type_in_schema, options)
-        self._type_out = VectorType._import_from_c(type_out_schema._addr())
+        self._type_out = GeometryExtensionType._import_from_c(type_out_schema._addr())
         self._type_in = type_in
 
     def push(self, arr):

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
@@ -1,6 +1,6 @@
 import pyarrow as pa
 
-from geoarrow.pyarrow._type import VectorType
+from geoarrow.pyarrow._type import GeometryExtensionType
 
 
 class VectorScalar(pa.ExtensionScalar):
@@ -76,5 +76,5 @@ def scalar_cls_from_name(name):
 
 
 # Inject array_cls_from_name exactly once to avoid circular import
-if VectorType._scalar_cls_from_name is None:
-    VectorType._scalar_cls_from_name = scalar_cls_from_name
+if GeometryExtensionType._scalar_cls_from_name is None:
+    GeometryExtensionType._scalar_cls_from_name = scalar_cls_from_name

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
@@ -3,7 +3,7 @@ import pyarrow as pa
 from geoarrow.pyarrow._type import GeometryExtensionType
 
 
-class VectorScalar(pa.ExtensionScalar):
+class GeometryExtensionScalar(pa.ExtensionScalar):
     def to_shapely(self):
         """
         Convert an array item to a shapely geometry
@@ -30,27 +30,27 @@ class WkbScalar(pa.ExtensionScalar):
         return from_wkb(self.value.as_py())
 
 
-class PointScalar(VectorScalar):
+class PointScalar(GeometryExtensionScalar):
     pass
 
 
-class LinestringScalar(VectorScalar):
+class LinestringScalar(GeometryExtensionScalar):
     pass
 
 
-class PolygonScalar(VectorScalar):
+class PolygonScalar(GeometryExtensionScalar):
     pass
 
 
-class MultiPointScalar(VectorScalar):
+class MultiPointScalar(GeometryExtensionScalar):
     pass
 
 
-class MultiLinestringScalar(VectorScalar):
+class MultiLinestringScalar(GeometryExtensionScalar):
     pass
 
 
-class MultiPolygonScalar(VectorScalar):
+class MultiPolygonScalar(GeometryExtensionScalar):
     pass
 
 

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_type.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_type.py
@@ -573,7 +573,7 @@ def multipolygon() -> MultiPolygonType:
     return _make_default(lib.GeometryType.MULTIPOLYGON, MultiPolygonType)
 
 
-def vector_type(
+def extension_type(
     geometry_type,
     dimensions=lib.Dimensions.XY,
     coord_type=lib.CoordType.SEPARATE,
@@ -584,7 +584,7 @@ def vector_type(
     """Generic vector geometry type constructor.
 
     >>> import geoarrow.pyarrow as ga
-    >>> ga.vector_type(ga.GeometryType.POINT, crs="EPSG:1234")
+    >>> ga.extension_type(ga.GeometryType.POINT, crs="EPSG:1234")
     PointType(geoarrow.point <EPSG:1234>)
     """
     ctype = lib.CVectorType.Make(geometry_type, dimensions, coord_type)
@@ -616,16 +616,16 @@ def _vector_type_common2(a, b):
     return wkb().with_metadata(metadata_a)
 
 
-def vector_type_common(types):
+def geometry_type_common(types):
     """Compute common type
 
     From a sequence of GeoArrow types, return a type to which all can be cast
     or error if this cannot occur.
 
     >>> import geoarrow.pyarrow as ga
-    >>> ga.vector_type_common([ga.wkb(), ga.point()])
+    >>> ga.geometry_type_common([ga.wkb(), ga.point()])
     WkbType(geoarrow.wkb)
-    >>> ga.vector_type_common([ga.point(), ga.point()])
+    >>> ga.geometry_type_common([ga.point(), ga.point()])
     PointType(geoarrow.point)
     """
     types = list(types)

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_type.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_type.py
@@ -3,7 +3,7 @@ import pyarrow as pa
 from geoarrow.c import lib
 
 
-class VectorType(pa.ExtensionType):
+class GeometryExtensionType(pa.ExtensionType):
     """Extension type base class for vector geometry types."""
 
     _extension_name = None
@@ -69,10 +69,10 @@ class VectorType(pa.ExtensionType):
         )
 
     def __arrow_ext_class__(self):
-        return VectorType._array_cls_from_name(self.extension_name)
+        return GeometryExtensionType._array_cls_from_name(self.extension_name)
 
     def __arrow_ext_scalar_class__(self):
-        return VectorType._scalar_cls_from_name(self.extension_name)
+        return GeometryExtensionType._scalar_cls_from_name(self.extension_name)
 
     def to_pandas_dtype(self):
         from geoarrow.pandas import GeoArrowExtensionDtype
@@ -258,7 +258,7 @@ class VectorType(pa.ExtensionType):
         return _ctype_to_extension_type(ctype)
 
 
-class WkbType(VectorType):
+class WkbType(GeometryExtensionType):
     """Extension type whose storage is a binary or large binary array of
     well-known binary. Even though the draft specification currently mandates
     ISO well-known binary, EWKB is supported by the parser.
@@ -267,7 +267,7 @@ class WkbType(VectorType):
     _extension_name = "geoarrow.wkb"
 
 
-class WktType(VectorType):
+class WktType(GeometryExtensionType):
     """Extension type whose storage is a utf8 or large utf8 array of
     well-known text.
     """
@@ -275,7 +275,7 @@ class WktType(VectorType):
     _extension_name = "geoarrow.wkt"
 
 
-class PointType(VectorType):
+class PointType(GeometryExtensionType):
     """Extension type whose storage is an array of points stored
     as either a struct with one child per dimension or a fixed-size
     list whose single child is composed of interleaved ordinate values.
@@ -295,7 +295,7 @@ class PointType(VectorType):
         return self._from_geobuffers_internal(buffers)
 
 
-class LinestringType(VectorType):
+class LinestringType(GeometryExtensionType):
     """Extension type whose storage is an array of linestrings stored
     as a list of points as described in :class:`PointType`.
     """
@@ -315,7 +315,7 @@ class LinestringType(VectorType):
         return self._from_geobuffers_internal(buffers)
 
 
-class PolygonType(VectorType):
+class PolygonType(GeometryExtensionType):
     """Extension type whose storage is an array of polygons stored
     as a list of a list of points as described in :class:`PointType`.
     """
@@ -338,7 +338,7 @@ class PolygonType(VectorType):
         return self._from_geobuffers_internal(buffers)
 
 
-class MultiPointType(VectorType):
+class MultiPointType(GeometryExtensionType):
     """Extension type whose storage is an array of polygons stored
     as a list of points as described in :class:`PointType`.
     """
@@ -358,7 +358,7 @@ class MultiPointType(VectorType):
         return self._from_geobuffers_internal(buffers)
 
 
-class MultiLinestringType(VectorType):
+class MultiLinestringType(GeometryExtensionType):
     """Extension type whose storage is an array of multilinestrings stored
     as a list of a list of points as described in :class:`PointType`.
     """
@@ -388,7 +388,7 @@ class MultiLinestringType(VectorType):
         return self._from_geobuffers_internal(buffers)
 
 
-class MultiPolygonType(VectorType):
+class MultiPolygonType(GeometryExtensionType):
     """Extension type whose storage is an array of multilinestrings stored
     as a list of a list of a list of points as described in :class:`PointType`.
     """
@@ -580,7 +580,7 @@ def vector_type(
     edge_type=lib.EdgeType.PLANAR,
     crs=None,
     crs_type=None,
-) -> VectorType:
+) -> GeometryExtensionType:
     """Generic vector geometry type constructor.
 
     >>> import geoarrow.pyarrow as ga
@@ -593,7 +593,9 @@ def vector_type(
 
 
 def _vector_type_common2(a, b):
-    if not isinstance(a, VectorType) or not isinstance(b, VectorType):
+    if not isinstance(a, GeometryExtensionType) or not isinstance(
+        b, GeometryExtensionType
+    ):
         raise ValueError(
             f"Can't compute common type between '{a}' and '{b}': non-geometry type"
         )

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/dataset.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/dataset.py
@@ -23,7 +23,7 @@ class GeoDataset:
 
     The GeoDataset wraps a pyarrow.Dataset containing one or more geometry columns
     and provides indexing and IO capability. If `geometry_columns` is `None`,
-    it will include all columns that inherit from `geoarrow.pyarrow.VectorType`.
+    it will include all columns that inherit from `geoarrow.pyarrow.GeometryExtensionType`.
     The `geometry_columns` are not required to be geoarrow extension type columns:
     text columns will be parsed as WKT; binary columns will be parsed as WKB
     (but are not detected automatically).

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/dataset.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/dataset.py
@@ -12,7 +12,7 @@ import pyarrow.dataset as _ds
 import pyarrow.compute as _compute
 import pyarrow.parquet as _pq
 from geoarrow.c.lib import CoordType
-from geoarrow.pyarrow._type import wkt, wkb, VectorType
+from geoarrow.pyarrow._type import wkt, wkb, GeometryExtensionType
 from geoarrow.pyarrow._kernel import Kernel
 
 
@@ -103,7 +103,7 @@ class GeoDataset:
             schema = self.schema
             geometry_columns = []
             for name, type in zip(schema.names, schema.types):
-                if isinstance(type, VectorType):
+                if isinstance(type, GeometryExtensionType):
                     geometry_columns.append(name)
             self._geometry_columns = tuple(geometry_columns)
 
@@ -130,7 +130,7 @@ class GeoDataset:
             geometry_types = []
             for col in self.geometry_columns:
                 type = self.schema.field(col).type
-                if isinstance(type, VectorType):
+                if isinstance(type, GeometryExtensionType):
                     geometry_types.append(type)
                 elif _types.is_binary(type):
                     geometry_types.append(wkb())

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
@@ -28,7 +28,7 @@ def read_pyogrio_table(*args, **kwargs):
     ...     ).to_file(temp_gpkg)
     ...     table = io.read_pyogrio_table(temp_gpkg)
     ...     table.column("geom").chunk(0)
-    VectorArray:WkbType(geoarrow.wkb <{"$schema":"https://proj.org/schem...>)[1]
+    GeometryExtensionArray:WkbType(geoarrow.wkb <{"$schema":"https://proj.org/schem...>)[1]
     <POINT (0 1)>
     """
     from pyogrio.raw import read_arrow

--- a/geoarrow-pyarrow/tests/test_pyarrow.py
+++ b/geoarrow-pyarrow/tests/test_pyarrow.py
@@ -11,7 +11,7 @@ import geoarrow.pyarrow._type as _type
 import geoarrow.pyarrow._array as _array
 
 
-def test_vector_type_basic():
+def test_geometry_type_basic():
     ctype = lib.CVectorType.Make(
         ga.GeometryType.POINT, ga.Dimensions.XY, ga.CoordType.SEPARATE
     )
@@ -31,7 +31,7 @@ def test_vector_type_basic():
         _type.LinestringType(ctype)
 
 
-def test_vector_type_with():
+def test_geometry_type_with():
     ctype = lib.CVectorType.Make(
         ga.GeometryType.POINT, ga.Dimensions.XY, ga.CoordType.SEPARATE
     )
@@ -67,7 +67,7 @@ def test_constructors():
     assert ga.multilinestring().extension_name == "geoarrow.multilinestring"
     assert ga.multipolygon().extension_name == "geoarrow.multipolygon"
 
-    generic = ga.vector_type(
+    generic = ga.extension_type(
         ga.GeometryType.POINT,
         ga.Dimensions.XYZ,
         ga.CoordType.INTERLEAVED,
@@ -83,10 +83,10 @@ def test_constructors():
 
 
 def test_type_common():
-    assert ga.vector_type_common([]) == ga.wkb()
-    assert ga.vector_type_common([ga.wkt()]) == ga.wkt()
-    assert ga.vector_type_common([ga.point(), ga.point()]) == ga.point()
-    assert ga.vector_type_common([ga.point(), ga.linestring()]) == ga.wkb()
+    assert ga.geometry_type_common([]) == ga.wkb()
+    assert ga.geometry_type_common([ga.wkt()]) == ga.wkt()
+    assert ga.geometry_type_common([ga.point(), ga.point()]) == ga.point()
+    assert ga.geometry_type_common([ga.point(), ga.linestring()]) == ga.wkb()
 
 
 def test_register_extension_types():

--- a/geoarrow-pyarrow/tests/test_pyarrow.py
+++ b/geoarrow-pyarrow/tests/test_pyarrow.py
@@ -145,7 +145,7 @@ def test_array():
 def test_array_repr():
     array = ga.array(["POINT (30 10)"])
     array_repr = repr(array)
-    assert array_repr.startswith("VectorArray")
+    assert array_repr.startswith("GeometryExtensionArray")
     assert "<POINT (30 10)>" in array_repr
 
     array = ga.array(["POINT (30 10)"] * 12)
@@ -160,7 +160,7 @@ def test_array_repr():
 
     array = ga.array(["THIS IS TOTALLY INVALID WKT"])
     array_repr = repr(array)
-    assert array_repr.startswith("VectorArray")
+    assert array_repr.startswith("GeometryExtensionArray")
     assert "* 1 or more display values failed to parse" in array_repr
 
 
@@ -189,14 +189,14 @@ def test_kernel_as():
     out = kernel.push(array)
     assert out.type.extension_name == "geoarrow.wkt"
     assert out.type.crs == "EPSG:1234"
-    assert isinstance(out, _array.VectorArray)
+    assert isinstance(out, _array.GeometryExtensionArray)
 
     array = ga.array(["POINT (30 10)"], ga.wkt().with_crs("EPSG:1234"))
     kernel = ga.Kernel.as_wkb(array.type)
     out = kernel.push(array)
     assert out.type.extension_name == "geoarrow.wkb"
     assert out.type.crs == "EPSG:1234"
-    assert isinstance(out, _array.VectorArray)
+    assert isinstance(out, _array.GeometryExtensionArray)
 
     if sys.byteorder == "little":
         wkb_item = b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x3e\x40\x00\x00\x00\x00\x00\x00\x24\x40"


### PR DESCRIPTION
...before anybody actually uses this!

Unfortunately, `GeometryType` is a no go because it's the enum name. It's a base class, so hopefully not an issue that it's more verbose.