### PR TITLE
geoarrow python metapackage

### DIFF
--- a/geoarrow-metapackage/README.md
+++ b/geoarrow-metapackage/README.md
@@ -1,0 +1,11 @@
+# geoarrow
+
+This is a metapackage for the geoarrow namespace.
+
+The `geoarrow` Python libraries are distributed with [namespace packaging](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/), meaning that each python package `geoarrow-[submodule-name]` (imported as `geoarrow.[submodule-name]`) can be published to PyPI independently.
+
+In order to obtain relevant modules, you should install them from PyPI directly, e.g.:
+
+```
+pip install geoarrow-pyarrow
+```

--- a/geoarrow-metapackage/pyproject.toml
+++ b/geoarrow-metapackage/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "geoarrow"
+version = "0.1.0"
+description = 'Metapackage for geoarrow namespace.'
+readme = "README.md"
+requires-python = ">=3.7"
+license = "Apache-2.0"
+keywords = []
+authors = [
+  { name = "Kyle Barron", email = "kyle@developmentseed.org" },
+]
+classifiers = [
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+]
+dependencies = []
+
+[project.urls]
+Documentation = "https://geoarrow.org"
+Issues = "https://github.com/geoarrow/geoarrow-python/issues"
+Source = "https://github.com/geoarrow/geoarrow-python"


### PR DESCRIPTION
This is a metapackage for the `geoarrow` namespace on PyPI. [Native namespace packages](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#native-namespace-packages) are _implicit_ upon the fact that there is no `__init__.py` at the top level of a folder. So if `geoarrow.pyarrow` publishes a wheel with `geoarrow/pyarrow/__init__.py` but another package `geoarrow` publishes a wheel with `geoarrow/__init__.py`, then `geoarrow.pyarrow` will never be able to be imported because the latter will shadow the former.

This metapackage prevents someone else from taking the "geoarrow" name on PyPI, which lessens the chance that someone else will publish a Python package that exports `geoarrow/__init__.py`.

You can build the Python module with
```
pip install -U build
python -m build .
```

which will build a `tar.gz` and a wheel into `./dist`.

Then you can verify the output with:
```
virtualenv env
source ./env/bin/activate
pip install ./dist/geoarrow-0.1.0-py3-none-any.whl
```
The `geoarrow` package is installed and visible to pip:
```
> pip show geoarrow
Name: geoarrow
Version: 0.1.0
Summary: Metapackage for geoarrow namespace.
Home-page:
Author:
Author-email: Kyle Barron <kyle@developmentseed.org>
License:
Location: /Users/kyle/github/geoarrow/geoarrow-python/geoarrow-metapackage/env/lib/python3.11/site-packages
Requires:
Required-by:
```
But there's no `geoarrow` folder in `site-packages`:

```
> ls ./env/lib/python3.11/site-packages/geoarrow
ls: ./env/lib/python3.11/site-packages/geoarrow: No such file or directory
```

This means that if I also install `geoarrow-pyarrow` in the same virtualenv

```
> pip install ../geoarrow-pyarrow
```

Now the `geoarrow` folder in `site-packages` exists (but crucially does not have `__init__.py` at the top level):

```
> ls ./env/lib/python3.11/site-packages/geoarrow
c       pyarrow
```

and I can import and use `geoarrow.pyarrow`:

```
> python
Python 3.11.4 (main, Aug 10 2023, 18:50:38) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import geoarrow.pyarrow
>>> geoarrow.pyarrow.PointType
<class 'geoarrow.pyarrow._type.PointType'>
```

Closes https://github.com/geoarrow/geoarrow-python/issues/3