### PR TITLE
perf: Optimize pandas `GeoArrowExtensionArray.copy()`

### DIFF
--- a/geoarrow-pandas/tests/test_geoarrow_pandas.py
+++ b/geoarrow-pandas/tests/test_geoarrow_pandas.py
@@ -113,6 +113,7 @@ def test_array_basic_methods():
         ),
     )
 
+
 def test_array_basic_methods_chunked_data():
     pa_array = ga.array(["POINT (0 1)", "POINT (1 2)", None])
     array = gapd.GeoArrowExtensionArray(pa.chunked_array([pa_array]))

--- a/geoarrow-pandas/tests/test_geoarrow_pandas.py
+++ b/geoarrow-pandas/tests/test_geoarrow_pandas.py
@@ -113,6 +113,40 @@ def test_array_basic_methods():
         ),
     )
 
+def test_array_basic_methods_chunked_data():
+    pa_array = ga.array(["POINT (0 1)", "POINT (1 2)", None])
+    array = gapd.GeoArrowExtensionArray(pa.chunked_array([pa_array]))
+
+    assert array[0] == gapd.GeoArrowExtensionScalar("POINT (0 1)")
+    assert array[2] is None
+    assert isinstance(array[1:2], gapd.GeoArrowExtensionArray)
+    assert len(array[1:2]) == 1
+    assert array[1:2][0] == gapd.GeoArrowExtensionScalar("POINT (1 2)")
+    assert isinstance(array[[1]], gapd.GeoArrowExtensionArray)
+    assert array[[1]][0] == gapd.GeoArrowExtensionScalar("POINT (1 2)")
+
+    assert len(array) == 3
+    assert all(array[:2] == array[:2])
+    assert array.dtype == gapd.GeoArrowExtensionDtype(ga.wkt())
+    assert array.nbytes == pa_array.nbytes
+    assert isinstance(array.take(np.array([1])), gapd.GeoArrowExtensionArray)
+    assert array.take(np.array([1]))[0] == gapd.GeoArrowExtensionScalar("POINT (1 2)")
+    np.testing.assert_array_equal(array.isna(), np.array([False, False, True]))
+
+    assert isinstance(array.copy(), gapd.GeoArrowExtensionArray)
+    assert array.copy()[0] == gapd.GeoArrowExtensionScalar("POINT (0 1)")
+
+    np.testing.assert_array_equal(
+        array.to_numpy(),
+        np.array(
+            [
+                gapd.GeoArrowExtensionScalar("POINT (0 1)"),
+                gapd.GeoArrowExtensionScalar("POINT (1 2)"),
+                None,
+            ]
+        ),
+    )
+
 
 def test_array_concat():
     pa_array_wkt = ga.array(["POINT (0 1)", "POINT (1 2)", None])


### PR DESCRIPTION
Credit to @martinfleis for the epic traceback that highlighted this and @jorisvandenbossche for the `concat_arrays()` trick!

```python
import geoarrow.pandas as gapd
import geoarrow.pyarrow as ga
import numpy as np

pts_array = ga.point().from_geobuffers(
    None, np.random.random(int(1e6)), np.random.random(int(1e6))
)

pts_pd = gapd.GeoArrowExtensionArray(pts_array)

%timeit pts_pd.copy()
#> Before this PR:
#> 37.8 s ± 188 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
#> After this PR:
#> 630 µs ± 22.4 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```