### PR TITLE
fix(geoarrow-pyarrow): Better geometry_names, geography column support, and default geometry column name

### DIFF
--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
@@ -393,8 +393,10 @@ def _geoparquet_encode_chunked_array(
         item_calc = item
 
     # geometry_types that are fixed at the data type level have already been
-    # added to the spec in an earlier step
-    if add_geometry_types is True and "geometry_types" not in spec:
+    # added to the spec in an earlier step. The unique_geometry_types()
+    # function is sufficiently optimized such that this potential
+    # re-computation is not expensive.
+    if add_geometry_types is True:
         _geoparquet_update_spec_geometry_types(item_calc, spec)
 
     if add_bbox:

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
@@ -41,23 +41,42 @@ def read_pyogrio_table(*args, **kwargs):
     meta, table = read_arrow(*args, **kwargs)
 
     # When meta["geometry_name"] is `""`, the geometry column name is wkb_geometry
-    # in GDAL's Arrow output
+    # in GDAL's Arrow output. This occurs for sources like shapefile whose geometry
+    # has no source-provided name. When GDAL >=3.8 is available, we should pass
+    # GEOMETRY_METADATA_ENCODING=GEOARROW, which will ensure that columns are already
+    # GeoArrow-encoded.
     geometry_name = meta["geometry_name"] if meta["geometry_name"] else "wkb_geometry"
+    geometry_index = table.schema.get_field_index(geometry_name)
+
+    # Check that we actually have a geometry column
+    geometry_field = table.schema.field(geometry_index)
+    geometry_metadata = geometry_field.metadata
+    field_is_geometry = (
+        geometry_metadata
+        and b"ARROW:extension:name" in geometry_metadata
+        and geometry_metadata[b"ARROW:extension:name"] == b"ogc.wkb"
+    )
+    if not field_is_geometry:
+        raise ValueError(
+            f"Expected field {geometry_index} ({geometry_name})' to have extension "
+            f"name 'ogc.wkb' but got {geometry_field}"
+        )
+
+    # Rename wkb_geometry to geometry for consistency with GeoParquet and GeoPandas
+    if geometry_name == "wkb_geometry":
+        geometry_name_out = "geometry"
+    else:
+        geometry_name_out = geometry_name
 
     # Get the JSON representation of the CRS
     prj_as_json = pyproj.CRS(meta["crs"]).to_json()
 
     # Apply geoarrow type to geometry column. This doesn't scale to multiple geometry
     # columns, but it's unclear if other columns would share the same CRS.
-    for i, nm in enumerate(table.column_names):
-        if nm == geometry_name:
-            geometry = table.column(i)
-            geometry = _ga.wkb().wrap_array(geometry)
-            geometry = _ga.with_crs(geometry, prj_as_json)
-            table = table.set_column(i, nm, geometry)
-            break
-
-    return table
+    geometry = table.column(geometry_index)
+    geometry = _ga.wkb().wrap_array(geometry)
+    geometry = _ga.with_crs(geometry, prj_as_json)
+    return table.set_column(geometry_index, geometry_name_out, geometry)
 
 
 def read_geoparquet_table(*args, **kwargs):

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
@@ -100,8 +100,9 @@ def read_geoparquet_table(*args, **kwargs):
     else:
         geo_meta = {}
 
-    # Remove "geo" schema metadata key since after this transformation
-    # it will no longer contain valid encodings
+    # Remove "geo" schema metadata key since few transformations following
+    # the read operation check that schema metadata is valid (e.g., column
+    # subset or rename)
     non_geo_meta = {k: v for k, v in tab_metadata.items() if k != b"geo"}
     tab = tab.replace_schema_metadata(non_geo_meta)
 

--- a/geoarrow-pyarrow/tests/test_io.py
+++ b/geoarrow-pyarrow/tests/test_io.py
@@ -176,6 +176,15 @@ def test_guess_geometry_columns():
     assert guessed_wkt["geometry"] == {"encoding": "WKT"}
 
 
+def test_guess_geography_columns():
+    assert io._geoparquet_guess_geometry_columns(pa.schema([])) == {}
+
+    guessed_wkb = io._geoparquet_guess_geometry_columns(
+        pa.schema([pa.field("geography", pa.binary())])
+    )
+    assert list(guessed_wkb.keys()) == ["geography"]
+    assert guessed_wkb["geography"] == {"encoding": "WKB", "edges": "spherical"}
+
 def test_encode_chunked_array():
     with pytest.raises(ValueError, match="Expected column encoding 'WKB'"):
         io._geoparquet_encode_chunked_array(

--- a/geoarrow-pyarrow/tests/test_io.py
+++ b/geoarrow-pyarrow/tests/test_io.py
@@ -8,11 +8,12 @@ import geoarrow.pyarrow as ga
 from geoarrow.pyarrow import io
 
 
-def test_readpyogrio_table():
+def test_readpyogrio_table_gpkg():
     pyogrio = pytest.importorskip("pyogrio")
     geopandas = pytest.importorskip("geopandas")
 
     with tempfile.TemporaryDirectory() as tmpdir:
+        # Check gpkg (which has internal geometry column name)
         temp_gpkg = os.path.join(tmpdir, "test.gpkg")
         df = geopandas.GeoDataFrame(
             geometry=geopandas.GeoSeries.from_wkt(["POINT (0 1)"], crs="OGC:CRS84")
@@ -23,6 +24,14 @@ def test_readpyogrio_table():
         table = io.read_pyogrio_table(temp_gpkg)
         assert table.column("geom").type == ga.wkb().with_crs(crs_json)
         assert ga.format_wkt(table.column("geom")).to_pylist() == ["POINT (0 1)"]
+
+        # Check fgb (which does not have an internal geometry column name)
+        temp_fgb = os.path.join(tmpdir, "test.fgb")
+        pyogrio.write_dataframe(df, temp_fgb)
+
+        table = io.read_pyogrio_table(temp_fgb)
+        assert table.column("geometry").type == ga.wkb().with_crs(crs_json)
+        assert ga.format_wkt(table.column("geometry")).to_pylist() == ["POINT (0 1)"]
 
 
 def test_write_geoparquet_table():

--- a/geoarrow-pyarrow/tests/test_io.py
+++ b/geoarrow-pyarrow/tests/test_io.py
@@ -127,6 +127,13 @@ def test_geoparquet_guess_primary_geometry_column():
         == "geometry"
     )
 
+    assert (
+        io._geoparquet_guess_primary_geometry_column(
+            pa.schema([pa.field("geography", pa.binary())])
+        )
+        == "geography"
+    )
+
     with pytest.raises(ValueError, match="at least one geometry column"):
         io._geoparquet_guess_primary_geometry_column(
             pa.schema([pa.field("not_geom", pa.binary())])


### PR DESCRIPTION
As a follow-up to #34!

geography column support for "compatible" Parquet files:

```python
from geoarrow.pyarrow import io
import pyarrow as pa
from pyarrow import parquet

table = pa.table([pa.array(["LINESTIRNG (0 0, 1 1)"])], ["geography"])
parquet.write_table(table, "test.parquet")
table_out = io.read_geoparquet_table("test.parquet")
table_out["geography"].type
#> WktType(spherical geoarrow.wkt <PROJJSON:{"$schema": "[https://proj...>](https://proj...%3E/))
```

geography_names behaviour:

```python
import geoarrow.pyarrow as ga
from geoarrow.pyarrow import io
import pyarrow as pa
from pyarrow import parquet

table = pa.table([ga.as_geoarrow(["LINESTRING (0 0, 1 1)"])], ["geometry"])

# Default: write geometry_types if no computation is required to do so
io.write_geoparquet_table(table, "test.parquet")
parquet.read_schema("test.parquet").metadata[b"geo"]
#> b'{"version": "1.0.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["LineString"], "crs": null}}}'

# ...force omitting with write_geometry_types=False
io.write_geoparquet_table(table, "test.parquet", write_geometry_types=False)
parquet.read_schema("test.parquet").metadata[b"geo"]
#> b'{"version": "1.0.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "geometry_types": [], "crs": null}}}'

# ...force including with write_geometry_types=True, even when this involves an O(n) calculation
table = pa.table([ga.as_wkb(["LINESTRING (0 0, 1 1)"])], ["geometry"])
io.write_geoparquet_table(table, "test.parquet", write_geometry_types=True)
parquet.read_schema("test.parquet").metadata[b"geo"]
#> b'{"version": "1.0.0", "primary_column": "geometry", "columns": {"geometry": {"encoding": "WKB", "geometry_types": ["LineString"], "crs": null}}}'
```

Default geometry column name when GDAL says the geometry column name is "":

```python
from geoarrow.pyarrow import io

io.read_pyogrio_table("https://github.com/geoarrow/geoarrow-data/releases/download/v0.1.0/ns-water-basin_point.fgb.zip")
```

```
pyarrow.Table
OBJECTID: int64
FEAT_CODE: string
BASIN_NAME: string
RIVER: string
HID: string
geometry: extension<geoarrow.wkb<WkbType>>
----
OBJECTID: [[1,2,3,4,5,...,42,43,44,45,46]]
FEAT_CODE: [["WABA30","WABA30","WABA30","WABA30","WABA30",...,"WABA30","WABA30","WABA30","WABA30","WABA30"]]
BASIN_NAME: [["01EB000","01EC000","01EA000","01DA000","01ED000",...,"01FE000","01FB000","01FC000","01FD000","01EQ000"]]
RIVER: [["BARRINGTON/CLYDE","ROSEWAY/SABLE/JORDAN","TUSKET RIVER","METEGHAN","MERSEY",...,"INDIAN","MARGAREE","CHETICAMP RIVER","WRECK COVE","NEW HBR/SALMON"]]
HID: [["919201D6D5094930ABF2D49BCEA27FC9","5293753C835142939326618A9513D35E","A7592A93F7A44022BCEC9D958BF46415","47EF929A586E4B429F51DC7A72BFEFE8","425CA3DB74F449E6AD6FC1E83130C813",...,"6A07E160F7C0425893FED13BAD9C742B","B4104D50CA2942C084E38F448FC4F059","133E00BAF7594C4FB5A23A4B30A6E8F1","B0B72EECDB734AB5BB20A668667AC5D5","7CD66433BC7C45A69E9506453C213ED9"]]
geometry: [[...]]
```