### PR TITLE
fix: Use pyarrow_hotfix everywhere

### DIFF
--- a/geoarrow-pandas/src/geoarrow/pandas/lib.py
+++ b/geoarrow-pandas/src/geoarrow/pandas/lib.py
@@ -1,6 +1,7 @@
 import re as _re
 import pandas as _pd
 import pyarrow as _pa
+import pyarrow_hotfix as _
 import numpy as _np
 from geoarrow.c import lib
 import geoarrow.pyarrow as _ga

--- a/geoarrow-pyarrow/pyproject.toml
+++ b/geoarrow-pyarrow/pyproject.toml
@@ -23,7 +23,7 @@ description = ""
 authors = [{name = "Dewey Dunnington", email = "dewey@dunnington.ca"}]
 license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
-dependencies = ["geoarrow-c", "pyarrow"]
+dependencies = ["geoarrow-c", "pyarrow", "pyarrow_hotfix"]
 
 [project.optional-dependencies]
 test = ["pytest", "pandas", "numpy", "geopandas", "pyogrio", "pyproj"]

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
@@ -1,4 +1,5 @@
 import pyarrow as pa
+import pyarrow_hotfix as _
 
 from geoarrow.c import lib
 

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
@@ -1,7 +1,7 @@
 import pyarrow as pa
 import pyarrow.compute as pc
-
-from geoarrow.c.lib import GeometryType, Dimensions, CoordType, EdgeType
+import pyarrow_hotfix as _
+from geoarrow.c.lib import CoordType, Dimensions, EdgeType, GeometryType
 from geoarrow.pyarrow import _type
 from geoarrow.pyarrow._array import array
 from geoarrow.pyarrow._kernel import Kernel
@@ -546,8 +546,8 @@ def to_geopandas(obj):
     0    POINT (0.00000 1.00000)
     dtype: geometry
     """
-    import pandas as pd
     import geopandas
+    import pandas as pd
 
     # Ideally we will avoid serialization via geobuffers + from_ragged_array()
     wkb_array_or_chunked = as_wkb(obj)

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_kernel.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_kernel.py
@@ -1,7 +1,7 @@
 import sys
 
 import pyarrow as pa
-
+import pyarrow_hotfix as _
 from geoarrow.c import lib
 from geoarrow.pyarrow._type import GeometryExtensionType
 

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
@@ -1,7 +1,7 @@
 import pyarrow as pa
-
-from geoarrow.pyarrow._type import GeometryExtensionType
+import pyarrow_hotfix as _
 from geoarrow.pyarrow._kernel import Kernel
+from geoarrow.pyarrow._type import GeometryExtensionType
 
 
 class GeometryExtensionScalar(pa.ExtensionScalar):

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_type.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_type.py
@@ -1,7 +1,7 @@
 import json
 
 import pyarrow as pa
-
+import pyarrow_hotfix as _
 from geoarrow.c import lib
 
 

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/dataset.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/dataset.py
@@ -7,13 +7,14 @@ Experimental geospatial-agumented wrapper around a ``pyarrow.dataset``.
 from concurrent.futures import ThreadPoolExecutor, wait
 
 import pyarrow as _pa
-import pyarrow.types as _types
-import pyarrow.dataset as _ds
 import pyarrow.compute as _compute
+import pyarrow.dataset as _ds
 import pyarrow.parquet as _pq
+import pyarrow.types as _types
+import pyarrow_hotfix as _
 from geoarrow.c.lib import CoordType
-from geoarrow.pyarrow._type import wkt, wkb, GeometryExtensionType
 from geoarrow.pyarrow._kernel import Kernel
+from geoarrow.pyarrow._type import GeometryExtensionType, wkb, wkt
 
 
 class GeoDataset:

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
@@ -7,9 +7,11 @@ testing and documenting the GeoArrow format and encodings.
 """
 
 import json
+
+import geoarrow.pyarrow as _ga
 import pyarrow.parquet as _pq
 import pyarrow.types as _types
-import geoarrow.pyarrow as _ga
+import pyarrow_hotfix as _
 from geoarrow.pyarrow._compute import ensure_storage
 
 
@@ -35,8 +37,8 @@ def read_pyogrio_table(*args, **kwargs):
     GeometryExtensionArray:WkbType(geoarrow.wkb <{"$schema":"https://proj.org/schem...>)[1]
     <POINT (0 1)>
     """
-    from pyogrio.raw import read_arrow
     import pyproj
+    from pyogrio.raw import read_arrow
 
     meta, table = read_arrow(*args, **kwargs)
 


### PR DESCRIPTION
Ensures that `pyarrow_hotfix` is imported everywhere we import pyarrow.