### PR TITLE
fix(geoarrow-pyarrow): Ensure/prefer ISO WKB where possible

### DIFF
--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
@@ -144,7 +144,9 @@ def array(obj, type_=None, *args, **kwargs) -> GeometryExtensionArray:
                 type_ = wkb().with_crs(str(obj.crs))
         else:
             type_ = wkb()
-        obj = obj.to_wkb()
+
+        # Prefer ISO WKB
+        obj = obj.to_wkb(flavor="iso")
 
     # Convert obj to array if it isn't already one
     if isinstance(obj, pa.Array) or isinstance(obj, pa.ChunkedArray):

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
@@ -225,9 +225,14 @@ def as_wkb(obj, strict_iso_wkb=False):
     GeometryExtensionArray:WkbType(geoarrow.wkb)[1]
     <POINT (0 1)>
     """
+    obj = obj_as_array_or_chunked(obj)
+
+    # If we're generating the WKB, we know it will be ISO, so no need to check
+    check_wkb = isinstance(obj.type, _type.WkbType)
+
     obj = as_geoarrow(obj, _type.wkb())
 
-    if strict_iso_wkb and _any_ewkb(obj):
+    if check_wkb and strict_iso_wkb and _any_ewkb(obj):
         return push_all(
             Kernel.as_geoarrow, obj, args={"type_id": _type.wkb().geoarrow_id}
         )

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
@@ -143,6 +143,7 @@ def write_geoparquet_table(
     geometry_columns=None,
     write_bbox=False,
     write_geometry_types=None,
+    check_wkb=True,
     **kwargs,
 ):
     """Write GeoParquet using PyArrow
@@ -178,6 +179,7 @@ def write_geoparquet_table(
                     geo_meta["columns"][name],
                     add_geometry_types=write_geometry_types,
                     add_bbox=write_bbox,
+                    check_wkb=check_wkb,
                 ),
             )
 
@@ -378,11 +380,11 @@ def _geoparquet_update_spec_bbox(item, spec):
 
 
 def _geoparquet_encode_chunked_array(
-    item, spec, add_geometry_types=None, add_bbox=False
+    item, spec, add_geometry_types=None, add_bbox=False, check_wkb=True
 ):
     # ...because we're currently only ever encoding using WKB
     if spec["encoding"] == "WKB":
-        item_out = _ga.as_wkb(item)
+        item_out = _ga.as_wkb(item, strict_iso_wkb=check_wkb)
     else:
         encoding = spec["encoding"]
         raise ValueError(f"Expected column encoding 'WKB' but got '{encoding}'")


### PR DESCRIPTION
- Adds a `strict_iso_wkb` option to `as_wkb()`
- Exposes this option in `io.write_geoparquet()`
- Ensures geopandas arrays are converted directly to ISO WKB

On my computer this is about 20ms per million points (to verify that all items in an ISO WKB array are actually ISO WKB encoded).

```python
import pyarrow as pa
import geoarrow.pyarrow as ga
import numpy as np

n = int(1e6)
xs = np.random.random(n)
ys = np.random.random(n)
zs = np.random.random(n)
points = ga.point().with_dimensions(ga.Dimensions.XYZ).from_geobuffers(None, xs, ys, zs)
gp = ga.to_geopandas(points)
ewkb = pa.array(gp.to_wkb())
not_ewkb = ga.as_wkb(ewkb, strict_iso_wkb=True)

# Best case detection
%timeit ga._compute._any_ewkb(ewkb)
#> 35.9 µs ± 215 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# Worst case detection (can probably optimize better in geoarrow-c)
%timeit ga._compute._any_ewkb(not_ewkb)
#> 20.1 ms ± 91.7 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

# Comes out about even to fix it
%timeit ga.as_wkb(not_ewkb, strict_iso_wkb=True)
#> 20.1 ms ± 41.3 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
%timeit ga.as_wkb(ewkb, strict_iso_wkb=True)
#> 23.8 ms ± 116 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```