### PR TITLE
feat(geoarrow-pyarrow): Implement single-geometry encodings for geoparquet writer

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,12 +49,14 @@ jobs:
       - name: Run doctests (geoarrow-pyarrow)
         if: success() && matrix.python-version == '3.12'
         run: |
-          pytest --pyargs geoarrow.pyarrow --doctest-modules --import-mode=append
+          cd geoarrow-pyarrow
+          pytest --doctest-modules
 
       - name: Run doctests (geoarrow-pandas)
         if: success() && matrix.python-version == '3.12'
         run: |
-          pytest --pyargs geoarrow.pandas --doctest-modules --import-mode=importlib
+          cd geoarrow-pandas
+          pytest --doctest-modules
 
   coverage:
     needs: [test]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v3
@@ -47,12 +47,12 @@ jobs:
           pytest geoarrow-pandas/tests -v -s
 
       - name: Run doctests (geoarrow-pyarrow)
-        if: success() && matrix.python-version == '3.11'
+        if: success() && matrix.python-version == '3.12'
         run: |
           pytest --pyargs geoarrow.pyarrow --doctest-modules --import-mode=importlib
 
       - name: Run doctests (geoarrow-pandas)
-        if: success() && matrix.python-version == '3.11'
+        if: success() && matrix.python-version == '3.12'
         run: |
           pytest --pyargs geoarrow.pandas --doctest-modules --import-mode=importlib
 
@@ -67,7 +67,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
 
       - name: Install (geoarrow-pyarrow)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Run doctests (geoarrow-pyarrow)
         if: success() && matrix.python-version == '3.12'
         run: |
-          pytest --pyargs geoarrow.pyarrow --doctest-modules --import-mode=importlib
+          pytest --pyargs geoarrow.pyarrow --doctest-modules
 
       - name: Run doctests (geoarrow-pandas)
         if: success() && matrix.python-version == '3.12'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Run doctests (geoarrow-pyarrow)
         if: success() && matrix.python-version == '3.12'
         run: |
-          pytest --pyargs geoarrow.pyarrow --doctest-modules
+          pytest --pyargs geoarrow.pyarrow --doctest-modules --import-mode=append
 
       - name: Run doctests (geoarrow-pandas)
         if: success() && matrix.python-version == '3.12'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,13 +50,13 @@ jobs:
         if: success() && matrix.python-version == '3.12'
         run: |
           cd geoarrow-pyarrow
-          pytest --doctest-modules
+          pytest --pyargs geoarrow.pyarrow --doctest-modules --import-mode=importlib
 
       - name: Run doctests (geoarrow-pandas)
         if: success() && matrix.python-version == '3.12'
         run: |
           cd geoarrow-pandas
-          pytest --doctest-modules
+          pytest --pyargs geoarrow.pandas --doctest-modules --import-mode=importlib
 
   coverage:
     needs: [test]

--- a/geoarrow-pandas/pyproject.toml
+++ b/geoarrow-pandas/pyproject.toml
@@ -41,3 +41,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 root = ".."
+
+[tool.pytest.ini_options]
+consider_namespace_packages = true

--- a/geoarrow-pyarrow/pyproject.toml
+++ b/geoarrow-pyarrow/pyproject.toml
@@ -41,3 +41,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 root = ".."
+
+[tool.pytest.ini_options]
+consider_namespace_packages = true

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
@@ -124,7 +124,7 @@ def unique_geometry_types(obj):
     return pa.array(py_geometry_types, type=out_type)
 
 
-def infer_type_common(obj, coord_type=None, promote_multi=False):
+def infer_type_common(obj, coord_type=None, promote_multi=False, _geometry_types=None):
     """Infer a common :class:`geoarrow.pyarrow.GeometryExtensionType` for the
     geometries in ``obj``, preferring geoarrow-encoded types and falling back
     to well-known binary.
@@ -148,7 +148,11 @@ def infer_type_common(obj, coord_type=None, promote_multi=False):
     if coord_type is None:
         coord_type = CoordType.SEPARATE
 
-    types = unique_geometry_types(obj)
+    if _geometry_types is None:
+        types = unique_geometry_types(obj)
+    else:
+        types = _geometry_types
+
     if len(types) == 0:
         # Not ideal: we probably want a _type.empty() that keeps the CRS
         return pa.null()

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
@@ -431,9 +431,7 @@ def _geoparquet_encode_chunked_array(
                 "Can't encode column with incompatable geometry types as geoarrow"
             )
 
-        inferred_geoarrow_encoding = geoarrow_type._extension_name.removeprefix(
-            "geoarrow."
-        )
+        inferred_geoarrow_encoding = geoarrow_type._extension_name[len("geoarrow.") :]
 
     # If the encoding was the "give me any geoarrow" sentinel, we need to
     # update it to be an actual valid encoding value

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
@@ -384,11 +384,20 @@ def _geoparquet_metadata_from_schema(
         add_geometry_types=add_geometry_types,
         encoding=encoding,
     )
+
     return {
-        "version": "1.0.0",
+        "version": _geoparquet_get_version_from_columns(columns),
         "primary_column": primary_geometry_column,
         "columns": columns,
     }
+
+
+def _geoparquet_get_version_from_columns(columns):
+    for column in columns.values():
+        if column["encoding"] != "WKB":
+            return "1.1.0"
+
+    return "1.0.0"
 
 
 def _geoparquet_update_spec_geometry_types(item, spec, unique_geometry_types=None):

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
@@ -416,7 +416,11 @@ def _geoparquet_encode_chunked_array(
         item_out = _ga.as_wkb(item, strict_iso_wkb=check_wkb)
 
         # If input was WKT, use the WKB-encoded value to perform calculations
-        if _pa.types.is_string(item.type) or isinstance(item.type, _ga.WktType):
+        if (
+            _pa.types.is_string(item.type)
+            or _pa.types.is_large_string(item.type)
+            or isinstance(item.type, _ga.WktType)
+        ):
             item_calc = item_out
         else:
             item_calc = item

--- a/geoarrow-pyarrow/tests/test_io.py
+++ b/geoarrow-pyarrow/tests/test_io.py
@@ -270,6 +270,11 @@ def test_encode_chunked_array():
             ga.array("POINT (0 1)"), {"encoding": "NotAnEncoding"}
         )
 
+    with pytest.raises(ValueError, match="Can't write one or more columns"):
+        io._geoparquet_encode_chunked_array(
+            ga.array(["POINT (0 1)", "LINESTRING (0 0, 1 1)"]), {"encoding": "geoarrow"}
+        )
+
     spec = {"encoding": "WKB"}
     encoded = io._geoparquet_encode_chunked_array(ga.as_wkb(["POINT (0 1)"]), spec)
     assert encoded.type == pa.binary()

--- a/geoarrow-pyarrow/tests/test_io.py
+++ b/geoarrow-pyarrow/tests/test_io.py
@@ -55,6 +55,8 @@ def test_write_geoparquet_table_wkb():
         io.write_geoparquet_table(tab, temp_pq, geometry_encoding="WKB")
         tab2 = parquet.read_table(temp_pq)
         assert b"geo" in tab2.schema.metadata
+        meta = json.loads(tab2.schema.metadata[b"geo"])
+        assert meta["version"] == "1.0.0"
         assert tab2.schema.types[0] == pa.binary()
 
 
@@ -68,6 +70,7 @@ def test_write_geoparquet_table_geoarrow():
         tab2 = parquet.read_table(temp_pq)
         assert b"geo" in tab2.schema.metadata
         meta = json.loads(tab2.schema.metadata[b"geo"])
+        assert meta["version"] == "1.1.0"
         assert meta["columns"]["geometry"]["encoding"] == "point"
         assert tab2.schema.types[0] == ga.point().storage_type
 


### PR DESCRIPTION


```python
import geoarrow.pyarrow as ga
from geoarrow.pyarrow import io
from pyarrow import parquet

# Read file
points_tbl = io.read_pyogrio_table(
    "https://github.com/geoarrow/geoarrow-data/releases/download/v0.1.0/ns-water-water_junc.fgb.zip",
    columns=["geometry"],
)

# Encode as point instead of multipoint
points_tbl = points_tbl.set_column(
    0, "geometry", ga.make_point(*ga.point_coords(points_tbl["geometry"]))
)

# Generally faster to do things with actual values (i.e., skip WKB parsing)
def read_and_do_something_with_values(f):
    tbl = io.read_geoparquet_table(f)
    ga.box_agg(tbl["geometry"])

io.write_geoparquet_table(points_tbl, "test.parquet", geometry_encoding="WKB")
%timeit read_and_do_something_with_values("test.parquet")
#> 10.6 ms ± 87.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

io.write_geoparquet_table(
    points_tbl,
    "test.parquet",
    geometry_encoding=io.geoparquet_encoding_geoarrow()
)
%timeit read_and_do_something_with_values("test.parquet")
#> 3.06 ms ± 13.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# Column statistics built in
io.write_geoparquet_table(
    points_tbl, 
    "test.parquet",
    geometry_encoding=io.geoparquet_encoding_geoarrow(),
    row_group_size=4 * 65535
)

pq_file = parquet.ParquetFile("test.parquet")
col_index = pq_file.schema_arrow.get_field_index("geometry")
boxes = []
for i in range(pq_file.num_row_groups):
    metadata = pq_file.metadata.row_group(i)
    stats_x = metadata.column(col_index).statistics
    stats_y = metadata.column(col_index + 1).statistics

    if stats_x is None or stats_y is None:
        boxes.append(None)
    else:
        boxes.append(
            {
                "xmin": stats_x.min,
                "xmax": stats_x.max,
                "ymin": stats_y.min,
                "ymax": stats_y.max,
            }
        )

boxes
#> [{'xmin': 229121.2503498519,
#>   'xmax': 758291.4287697164,
#>   'ymin': 4807526.337270797,
#>   'ymax': 5190760.16706287},
#>  {'xmin': 302024.3820995989,
#>   'xmax': 716864.4139822095,
#>   'ymin': 4919890.0309867,
#>   'ymax': 5234346.876916235}]
```
