### PR TITLE
feat(geoarrow-types): pyarrow geometry extension type implementation

### DIFF
--- a/geoarrow-types/src/geoarrow/types/constants.py
+++ b/geoarrow-types/src/geoarrow/types/constants.py
@@ -116,10 +116,10 @@ class GeometryType(TypeSpecEnum):
     """
 
     UNSPECIFIED = -1
-    """Unknown or unspecified geometry type"""
+    """Unspecified geometry type"""
 
     GEOMETRY = 0
-    """Mixed geometry type"""
+    """Unknown or mixed geometry type"""
 
     POINT = 1
     """Point geometry type"""
@@ -162,8 +162,11 @@ class Dimensions(TypeSpecEnum):
     <Dimensions.XYZM: 4>
     """
 
-    UNSPECIFIED = 0
-    """Unknown or uninitialized dimensions"""
+    UNSPECIFIED = -1
+    """Unspecified dimensions"""
+
+    UNKNOWN = 0
+    """Unknown or mixed dimensions"""
 
     XY = 1
     """XY dimensions"""
@@ -176,6 +179,14 @@ class Dimensions(TypeSpecEnum):
 
     XYZM = 4
     """XYZM dimensions"""
+
+    @classmethod
+    def _common2(cls, lhs, rhs):
+        out = super()._common2(lhs, rhs)
+        if out is not None:
+            return out
+        else:
+            return cls.UNKNOWN
 
 
 class CoordType(TypeSpecEnum):

--- a/geoarrow-types/src/geoarrow/types/constants.py
+++ b/geoarrow-types/src/geoarrow/types/constants.py
@@ -180,6 +180,12 @@ class Dimensions(TypeSpecEnum):
     XYZM = 4
     """XYZM dimensions"""
 
+    def count(self):
+        if self in (Dimensions.UNSPECIFIED, Dimensions.UNKNOWN):
+            return 0
+        else:
+            return len(self.name)
+
     @classmethod
     def _common2(cls, lhs, rhs):
         out = super()._common2(lhs, rhs)

--- a/geoarrow-types/src/geoarrow/types/type_pyarrow.py
+++ b/geoarrow-types/src/geoarrow/types/type_pyarrow.py
@@ -203,6 +203,19 @@ def storage_type(spec: TypeSpec) -> pa.DataType:
         return _SERIALIZED_STORAGE_TYPES[spec.encoding]
 
 
+def _field_nesting(type_):
+    if isinstance(type_, pa.ListType):
+        f = type_.field(0)
+        return [f.name] + _field_nesting(f.type)
+    elif isinstance(type_, pa.StructType):
+        return tuple(type_.field(i).name for i in range(type_.num_fields))
+    elif isinstance(type_, pa.FixedSizeListType):
+        f = type_.field(0)
+        return (f.name,)
+    else:
+        raise ValueError(f"Type {type_} is not a valid GeoArrow type component")
+
+
 def _struct_fields(dims):
     return pa.struct([pa.field(c, pa.float64(), nullable=False) for c in dims])
 

--- a/geoarrow-types/src/geoarrow/types/type_pyarrow.py
+++ b/geoarrow-types/src/geoarrow/types/type_pyarrow.py
@@ -260,7 +260,7 @@ def _validate_storage_type(storage_type, spec):
     """Validate a storage type against a TypeSpec
 
     We don't currently call any constructor with validate_storage_type=True,
-    but if somebody does this it should error until is implemented.
+    but if somebody does this it should error until implemented.
     """
     raise NotImplementedError()
 
@@ -294,14 +294,23 @@ def _deserialize_storage(storage_type, extension_name=None, extension_metadata=N
     if type_name == "struct":
         names, parsed_children = params
         n_dims = len(names)
+        # We could use len(names) here, but we don't actually want to
+        # infer the dimensions if the struct field names are not valid
+        # (because it is typically very easy to set a struct's field names,
+        # as opposed to the fixed-size list where not all implementations
+        # expose that behaviour)
+        n_dims_infer = -1
     else:
         names, n_dims, parsed_children = params
+        n_dims_infer = n_dims
 
     if names in _DIMS_FROM_NAMES:
         dims = _DIMS_FROM_NAMES[names]
-    elif n_dims == 2:
+        if n_dims != dims.count():
+            raise ValueError(f"Expected {n_dims} dimensions but got Dimensions.{dims}")
+    elif n_dims_infer == 2:
         dims = Dimensions.XY
-    elif n_dims == 4:
+    elif n_dims_infer == 4:
         dims = Dimensions.XYZM
     else:
         raise ValueError(f"Can't infer dimensions from coord field names {names}")

--- a/geoarrow-types/src/geoarrow/types/type_pyarrow.py
+++ b/geoarrow-types/src/geoarrow/types/type_pyarrow.py
@@ -245,8 +245,10 @@ def _parse_storage(storage_type):
     elif isinstance(storage_type, pa.FixedSizeListType):
         f = storage_type.field(0)
         return [
-            "fixed_size_list",
-            (f.name, storage_type.list_size, (_parse_storage(f.type)[0],)),
+            (
+                "fixed_size_list",
+                (f.name, storage_type.list_size, (_parse_storage(f.type)[0],)),
+            ),
         ]
     else:
         raise ValueError(f"Type {storage_type} is not a valid GeoArrow type component")

--- a/geoarrow-types/src/geoarrow/types/type_pyarrow.py
+++ b/geoarrow-types/src/geoarrow/types/type_pyarrow.py
@@ -21,7 +21,7 @@ class GeometryExtensionType(pa.ExtensionType):
     def __init__(self, spec: TypeSpec):
         if not isinstance(spec, TypeSpec):
             raise TypeError("GeometryExtensionType must be created from a TypeSpec")
-        self._spec = spec
+        self._spec = spec.canonicalize()
 
         if self._spec.extension_name() != type(self)._extension_name:
             raise ValueError(

--- a/geoarrow-types/src/geoarrow/types/type_pyarrow.py
+++ b/geoarrow-types/src/geoarrow/types/type_pyarrow.py
@@ -1,0 +1,285 @@
+from typing import Optional
+
+from geoarrow.types.type_spec import TypeSpec
+from geoarrow.types.crs import Crs
+from geoarrow.types.constants import (
+    Encoding,
+    GeometryType,
+    Dimensions,
+    CoordType,
+    EdgeType,
+)
+
+import pyarrow as pa
+
+
+class GeometryExtensionType(pa.ExtensionType):
+    """Extension type base class for vector geometry types."""
+
+    _extension_name = None
+
+    def __init__(self, spec: TypeSpec):
+        if not isinstance(spec, TypeSpec):
+            raise TypeError("GeometryExtensionType must be created from a TypeSpec")
+        self._spec = spec
+
+        if self._spec.extension_name() != type(self)._extension_name:
+            raise ValueError(
+                f"Expected BaseType with extension name "
+                f'"{type(self)._extension_name}" but got "{self._spec.extension_name()}"'
+            )
+
+        if spec.encoding == Encoding.GEOARROW:
+            key = spec.geometry_type, spec.coord_type, spec.dimensions
+            storage_type = _NATIVE_STORAGE_TYPES[key]
+        else:
+            storage_type = _SERIALIZED_STORAGE_TYPES[spec.encoding]
+
+        pa.ExtensionType.__init__(self, storage_type, self._spec.extension_name())
+
+    def __repr__(self):
+        return f"{type(self).__name__}({repr(self._spec)})"
+
+    def __arrow_ext_serialize__(self):
+        return self._spec.extension_metadata().encode()
+
+    @classmethod
+    def __arrow_ext_deserialize__(cls, storage_type, serialized):
+        raise NotImplementedError()
+
+    def to_pandas_dtype(self):
+        from pandas import ArrowDtype
+
+        return ArrowDtype(self)
+
+    @property
+    def spec(self) -> TypeSpec:
+        return self._spec
+
+    @property
+    def encoding(self) -> Encoding:
+        return self._spec.encoding
+
+    @property
+    def geometry_type(self) -> GeometryType:
+        """The :class:`GeometryType` of this type or ``GEOMETRY`` for
+        types where this is not constant (i.e., WKT and WKB).
+
+        >>> import geoarrow.pyarrow as ga
+        >>> ga.wkb().geometry_type == ga.GeometryType.GEOMETRY
+        True
+        >>> ga.linestring().geometry_type == ga.GeometryType.LINESTRING
+        True
+        """
+        return self._spec.geometry_type
+
+    @property
+    def dimensions(self) -> Dimensions:
+        """The :class:`Dimensions` of this type or ``UNKNOWN`` for
+        types where this is not constant (i.e., WKT and WKT).
+
+        >>> import geoarrow.pyarrow as ga
+        >>> ga.wkb().dimensions == ga.Dimensions.UNKNOWN
+        True
+        >>> ga.linestring().dimensions == ga.Dimensions.XY
+        True
+        """
+        return self._spec.dimensions
+
+    @property
+    def coord_type(self) -> CoordType:
+        """The :class:`CoordType` of this type.
+
+        >>> import geoarrow.pyarrow as ga
+        >>> ga.linestring().coord_type == ga.CoordType.SEPARATE
+        True
+        >>> ga.linestring().with_coord_type(ga.CoordType.INTERLEAVED).coord_type
+        <GeoArrowCoordType.GEOARROW_COORD_TYPE_INTERLEAVED: 2>
+        """
+        return self._spec.coord_type
+
+    @property
+    def edge_type(self) -> EdgeType:
+        """The :class:`EdgeType` of this type.
+
+        >>> import geoarrow.pyarrow as ga
+        >>> ga.linestring().edge_type == ga.EdgeType.PLANAR
+        True
+        >>> ga.linestring().with_edge_type(ga.EdgeType.SPHERICAL).edge_type
+        <GeoArrowEdgeType.GEOARROW_EDGE_TYPE_SPHERICAL: 1>
+        """
+        return self._spec.edge_type
+
+    @property
+    def crs(self) -> Optional[Crs]:
+        """The coordinate reference system of this type.
+
+        >>> import geoarrow.pyarrow as ga
+        >>> ga.point().with_crs("EPSG:1234").crs
+        'EPSG:1234'
+        """
+        return self._spec.crs
+
+
+class WkbType(GeometryExtensionType):
+    """Extension type whose storage is a binary or large binary array of
+    well-known binary. Even though the draft specification currently mandates
+    ISO well-known binary, EWKB is supported by the parser.
+    """
+
+    _extension_name = "geoarrow.wkb"
+
+
+class WktType(GeometryExtensionType):
+    """Extension type whose storage is a utf8 or large utf8 array of
+    well-known text.
+    """
+
+    _extension_name = "geoarrow.wkt"
+
+
+class PointType(GeometryExtensionType):
+    """Extension type whose storage is an array of points stored
+    as either a struct with one child per dimension or a fixed-size
+    list whose single child is composed of interleaved ordinate values.
+    """
+
+    _extension_name = "geoarrow.point"
+
+
+class LinestringType(GeometryExtensionType):
+    """Extension type whose storage is an array of linestrings stored
+    as a list of points as described in :class:`PointType`.
+    """
+
+    _extension_name = "geoarrow.linestring"
+
+
+class PolygonType(GeometryExtensionType):
+    """Extension type whose storage is an array of polygons stored
+    as a list of a list of points as described in :class:`PointType`.
+    """
+
+    _extension_name = "geoarrow.polygon"
+
+
+class MultiPointType(GeometryExtensionType):
+    """Extension type whose storage is an array of polygons stored
+    as a list of points as described in :class:`PointType`.
+    """
+
+    _extension_name = "geoarrow.multipoint"
+
+
+class MultiLinestringType(GeometryExtensionType):
+    """Extension type whose storage is an array of multilinestrings stored
+    as a list of a list of points as described in :class:`PointType`.
+    """
+
+    _extension_name = "geoarrow.multilinestring"
+
+
+class MultiPolygonType(GeometryExtensionType):
+    """Extension type whose storage is an array of multilinestrings stored
+    as a list of a list of a list of points as described in :class:`PointType`.
+    """
+
+    _extension_name = "geoarrow.multipolygon"
+
+
+def extension_type(spec: TypeSpec) -> GeometryExtensionType:
+    spec = spec.with_defaults()
+    extension_cls = _EXTENSION_CLASSES[spec.extension_name()]
+    return extension_cls(spec)
+
+
+def storage_type(spec: TypeSpec) -> pa.DataType:
+    spec = spec.with_defaults()
+
+    if spec.encoding == Encoding.GEOARROW:
+        key = spec.geometry_type, spec.coord_type, spec.dimensions
+        return _NATIVE_STORAGE_TYPES[key]
+    else:
+        return _SERIALIZED_STORAGE_TYPES[spec.encoding]
+
+
+def _struct_fields(dims):
+    return pa.struct([pa.field(c, pa.float64(), nullable=False) for c in dims])
+
+
+def _interleaved_fields(dims):
+    return pa.list_(pa.field(dims, pa.float64(), nullable=False), len(dims))
+
+
+def _nested_field(coord, names):
+    if len(names) == 1:
+        return pa.field(names[-1], coord, nullable=False)
+    else:
+        inner_type = pa.list_(_nested_field(coord, names[:-1]))
+        return pa.field(names[-1], inner_type, nullable=False)
+
+
+def _nested_type(coord, names):
+    if len(names) > 0:
+        return pa.list_(_nested_field(coord, names))
+    else:
+        return coord
+
+
+def _generate_storage_types():
+    coord_storage = {
+        (CoordType.SEPARATED, Dimensions.XY): _struct_fields("xy"),
+        (CoordType.SEPARATED, Dimensions.XYZ): _struct_fields("xyz"),
+        (CoordType.SEPARATED, Dimensions.XYM): _struct_fields("xym"),
+        (CoordType.SEPARATED, Dimensions.XYZM): _struct_fields("xyzm"),
+        (CoordType.INTERLEAVED, Dimensions.XY): _interleaved_fields("xy"),
+        (CoordType.INTERLEAVED, Dimensions.XYZ): _interleaved_fields("xyz"),
+        (CoordType.INTERLEAVED, Dimensions.XYM): _interleaved_fields("xym"),
+        (CoordType.INTERLEAVED, Dimensions.XYZM): _interleaved_fields("xyzm"),
+    }
+
+    field_names = {
+        GeometryType.POINT: [],
+        GeometryType.LINESTRING: ["vertices"],
+        GeometryType.POLYGON: ["rings", "vertices"],
+        GeometryType.MULTIPOINT: ["points"],
+        GeometryType.MULTILINESTRING: ["linestrings", "vertices"],
+        GeometryType.MULTIPOLYGON: ["polygons", "rings", "vertices"],
+    }
+
+    all_geoemetry_types = list(field_names.keys())
+    all_coord_types = [CoordType.INTERLEAVED, CoordType.SEPARATED]
+    all_dimensions = [Dimensions.XY, Dimensions.XYZ, Dimensions.XYM, Dimensions.XYZM]
+
+    all_storage_types = {}
+    for geometry_type in all_geoemetry_types:
+        for coord_type in all_coord_types:
+            for dimensions in all_dimensions:
+                names = field_names[geometry_type]
+                coord = coord_storage[(coord_type, dimensions)]
+                key = geometry_type, coord_type, dimensions
+                storage_type = _nested_type(coord, names)
+                all_storage_types[key] = storage_type
+
+    return all_storage_types
+
+
+_EXTENSION_CLASSES = {
+    "geoarrow.wkb": WkbType,
+    "geoarrow.wkt": WktType,
+    "geoarrow.point": PointType,
+    "geoarrow.linestring": LinestringType,
+    "geoarrow.polygon": PolygonType,
+    "geoarrow.multipoint": MultiPointType,
+    "geoarrow.multilinestring": MultiLinestringType,
+    "geoarrow.multipolygon": MultiPolygonType,
+}
+
+_SERIALIZED_STORAGE_TYPES = {
+    Encoding.WKT: pa.utf8(),
+    Encoding.LARGE_WKT: pa.large_utf8(),
+    Encoding.WKB: pa.binary(),
+    Encoding.LARGE_WKB: pa.large_binary(),
+}
+
+_NATIVE_STORAGE_TYPES = _generate_storage_types()

--- a/geoarrow-types/src/geoarrow/types/type_spec.py
+++ b/geoarrow-types/src/geoarrow/types/type_spec.py
@@ -228,16 +228,6 @@ class TypeSpec(NamedTuple):
         )
 
     @staticmethod
-    def from_extension_name(extension_name: str):
-        if extension_name in _GEOMETRY_TYPE_FROM_EXT:
-            return TypeSpec(
-                encoding=Encoding.GEOARROW,
-                geometry_type=_GEOMETRY_TYPE_FROM_EXT[extension_name],
-            )
-        else:
-            return TypeSpec()
-
-    @staticmethod
     def from_extension_metadata(extension_metadata: str):
         if extension_metadata:
             metadata = json.loads(extension_metadata)

--- a/geoarrow-types/src/geoarrow/types/type_spec.py
+++ b/geoarrow-types/src/geoarrow/types/type_spec.py
@@ -69,6 +69,11 @@ class TypeSpec(NamedTuple):
 
         return json.dumps(metadata)
 
+    def to_pyarrow(self):
+        from geoarrow.types.type_pyarrow import extension_type
+
+        return extension_type(self)
+
     def with_defaults(self, defaults=None):
         """Apply defaults to unspecified fields
 

--- a/geoarrow-types/src/geoarrow/types/type_spec.py
+++ b/geoarrow-types/src/geoarrow/types/type_spec.py
@@ -182,6 +182,34 @@ class TypeSpec(NamedTuple):
             f"Can't create TypeSpec from object of type {type(obj).__name__}"
         )
 
+    @staticmethod
+    def from_extension_name(extension_name: str):
+        if extension_name in _GEOMETRY_TYPE_FROM_EXT:
+            return TypeSpec(
+                encoding=Encoding.GEOARROW,
+                geometry_type=_GEOMETRY_TYPE_FROM_EXT[extension_name],
+            )
+        else:
+            return TypeSpec()
+
+    @staticmethod
+    def from_extension_metadata(extension_metadata: str):
+        if extension_metadata:
+            metadata = json.loads(extension_metadata)
+        else:
+            metadata = {}
+
+        out_edges = EdgeType.PLANAR
+        out_crs = None
+
+        if "edges" in metadata:
+            out_edges = EdgeType.create(metadata["edges"])
+
+        if "crs" in metadata and metadata["crs"] is not None:
+            out_crs = crs.ProjJsonCrs(metadata["crs"])
+
+        return TypeSpec(edge_type=out_edges, crs=out_crs)
+
     @classmethod
     def coalesce(cls, *args):
         """Coalesce specified values
@@ -512,3 +540,5 @@ _GEOARROW_EXT_NAMES = {
     GeometryType.MULTILINESTRING: "geoarrow.multilinestring",
     GeometryType.MULTIPOLYGON: "geoarrow.multipolygon",
 }
+
+_GEOMETRY_TYPE_FROM_EXT = {v: k for k, v in _GEOARROW_EXT_NAMES.items()}

--- a/geoarrow-types/src/geoarrow/types/type_spec.py
+++ b/geoarrow-types/src/geoarrow/types/type_spec.py
@@ -224,6 +224,11 @@ class TypeSpec(NamedTuple):
 
     @staticmethod
     def from_extension_name(extension_name: str):
+        """Parse an extension name into a TypeSpec
+
+        Extracts the information from a GeoArrow extension name and places
+        it in a TypeSpec instance.
+        """
         if extension_name in _GEOMETRY_TYPE_FROM_EXT:
             return TypeSpec(
                 encoding=Encoding.GEOARROW,
@@ -234,6 +239,11 @@ class TypeSpec(NamedTuple):
 
     @staticmethod
     def from_extension_metadata(extension_metadata: str):
+        """Parse extension metadata into a TypeSpec
+
+        Extract the information from a serialized GeoArrow representation and
+        into a TypeSpec instance.
+        """
         if extension_metadata:
             metadata = json.loads(extension_metadata)
         else:

--- a/geoarrow-types/src/geoarrow/types/type_spec.py
+++ b/geoarrow-types/src/geoarrow/types/type_spec.py
@@ -228,6 +228,16 @@ class TypeSpec(NamedTuple):
         )
 
     @staticmethod
+    def from_extension_name(extension_name: str):
+        if extension_name in _GEOMETRY_TYPE_FROM_EXT:
+            return TypeSpec(
+                encoding=Encoding.GEOARROW,
+                geometry_type=_GEOMETRY_TYPE_FROM_EXT[extension_name],
+            )
+        else:
+            return TypeSpec()
+
+    @staticmethod
     def from_extension_metadata(extension_metadata: str):
         if extension_metadata:
             metadata = json.loads(extension_metadata)

--- a/geoarrow-types/src/geoarrow/types/type_spec.py
+++ b/geoarrow-types/src/geoarrow/types/type_spec.py
@@ -85,16 +85,11 @@ class TypeSpec(NamedTuple):
 
         return json.dumps(metadata)
 
-    def geoparquet_column_metadata(self) -> str:
-        metadata = {}
-
-        if self.edge_type == EdgeType.SPHERICAL:
-            metadata["edges"] = "spherical"
-
-        if self.crs is not None and self.crs is not crs.UNSPECIFIED:
-            metadata["crs"] = self.crs.to_json_dict()
-
-        return json.dumps(metadata)
+    def __arrow_c_schema__(self):
+        # We could potentially use nanoarrow or arro3 here,
+        # but use pyarrow if the module is already loaded to
+        # avoid requiring those as a dependency.
+        return self.to_pyarrow().__arrow_c_schema__()
 
     def to_pyarrow(self):
         from geoarrow.types.type_pyarrow import extension_type

--- a/geoarrow-types/tests/test_type_pyarrow.py
+++ b/geoarrow-types/tests/test_type_pyarrow.py
@@ -1,0 +1,71 @@
+import pyarrow as pa
+
+import geoarrow.types as gt
+from geoarrow.types import type_pyarrow
+
+
+def test_classes_serialized():
+    wkt = gt.wkt().to_pyarrow()
+    assert isinstance(wkt, type_pyarrow.WktType)
+    assert wkt.encoding == gt.Encoding.WKT
+
+    wkb = gt.wkb().to_pyarrow()
+    assert isinstance(wkb, type_pyarrow.WkbType)
+    assert wkb.encoding == gt.Encoding.WKB
+
+
+def test_geometry_types():
+    xy = pa.struct(
+        [
+            pa.field("x", pa.float64(), nullable=False),
+            pa.field("y", pa.float64(), nullable=False),
+        ]
+    )
+
+    point = gt.point().to_pyarrow()
+    assert isinstance(point, type_pyarrow.PointType)
+    assert point.encoding == gt.Encoding.GEOARROW
+    assert point.geometry_type == gt.GeometryType.POINT
+    assert point.storage_type == xy
+
+    linestring = gt.linestring().to_pyarrow()
+    assert isinstance(linestring, type_pyarrow.LinestringType)
+    assert linestring.encoding == gt.Encoding.GEOARROW
+    assert linestring.geometry_type == gt.GeometryType.LINESTRING
+    assert linestring.storage_type == pa.list_(pa.field("vertices", xy, False))
+
+    polygon = gt.polygon().to_pyarrow()
+    assert isinstance(polygon, type_pyarrow.PolygonType)
+    assert polygon.encoding == gt.Encoding.GEOARROW
+    assert polygon.geometry_type == gt.GeometryType.POLYGON
+    assert polygon.storage_type == pa.list_(
+        pa.field("rings", pa.list_(pa.field("vertices", xy, False)), False)
+    )
+
+    multipoint = gt.multipoint().to_pyarrow()
+    assert isinstance(multipoint, type_pyarrow.MultiPointType)
+    assert multipoint.encoding == gt.Encoding.GEOARROW
+    assert multipoint.geometry_type == gt.GeometryType.MULTIPOINT
+    assert multipoint.storage_type == pa.list_(pa.field("points", xy, False))
+
+    multilinestring = gt.multilinestring().to_pyarrow()
+    assert isinstance(multilinestring, type_pyarrow.MultiLinestringType)
+    assert multilinestring.encoding == gt.Encoding.GEOARROW
+    assert multilinestring.geometry_type == gt.GeometryType.MULTILINESTRING
+    assert polygon.storage_type == pa.list_(
+        pa.field("linestrings", pa.list_(pa.field("vertices", xy, False)), False)
+    )
+
+    multipolygon = gt.multipolygon().to_pyarrow()
+    assert isinstance(multipolygon, type_pyarrow.MultiPolygonType)
+    assert multipolygon.encoding == gt.Encoding.GEOARROW
+    assert multipolygon.geometry_type == gt.GeometryType.MULTIPOLYGON
+    assert multipolygon.storage_type == pa.list_(
+        pa.field(
+            "polygons",
+            pa.list_(
+                pa.field("rings", pa.list_(pa.field("vertices", xy, False)), False)
+            ),
+            False,
+        )
+    )

--- a/geoarrow-types/tests/test_type_pyarrow.py
+++ b/geoarrow-types/tests/test_type_pyarrow.py
@@ -1,4 +1,5 @@
 import pyarrow as pa
+import pytest
 
 import geoarrow.types as gt
 from geoarrow.types import type_pyarrow
@@ -69,3 +70,66 @@ def test_geometry_types():
             False,
         )
     )
+
+    with pytest.raises(ValueError, match="Can't compute extension name"):
+        gt.type_spec(gt.GeometryType.GEOMETRYCOLLECTION).to_pyarrow()
+
+
+def test_interleaved_dimensions():
+    point_xy = gt.point(dimensions="xy", coord_type="interleaved").to_pyarrow()
+    assert point_xy.coord_type == gt.CoordType.INTERLEAVED
+    assert point_xy.dimensions == gt.Dimensions.XY
+    assert point_xy.storage_type.field(0).name == "xy"
+
+    point_xyz = gt.point(dimensions="xyz", coord_type="interleaved").to_pyarrow()
+    assert point_xyz.coord_type == gt.CoordType.INTERLEAVED
+    assert point_xyz.dimensions == gt.Dimensions.XYZ
+    assert point_xyz.storage_type.field(0).name == "xyz"
+
+    point_xym = gt.point(dimensions="xym", coord_type="interleaved").to_pyarrow()
+    assert point_xym.coord_type == gt.CoordType.INTERLEAVED
+    assert point_xym.dimensions == gt.Dimensions.XYM
+    assert point_xym.storage_type.field(0).name == "xym"
+
+    point_xyzm = gt.point(dimensions="xyzm", coord_type="interleaved").to_pyarrow()
+    assert point_xyzm.coord_type == gt.CoordType.INTERLEAVED
+    assert point_xyzm.dimensions == gt.Dimensions.XYZM
+    assert point_xyzm.storage_type.field(0).name == "xyzm"
+
+
+def test_separated_dimensions():
+    point_xy = gt.point(dimensions="xy", coord_type="separated").to_pyarrow()
+    assert point_xy.coord_type == gt.CoordType.SEPARATED
+    assert point_xy.dimensions == gt.Dimensions.XY
+    storage_names = [
+        point_xy.storage_type.field(i).name
+        for i in range(point_xy.storage_type.num_fields)
+    ]
+    assert storage_names == ["x", "y"]
+
+    point_xyz = gt.point(dimensions="xyz", coord_type="separated").to_pyarrow()
+    assert point_xy.coord_type == gt.CoordType.SEPARATED
+    assert point_xyz.dimensions == gt.Dimensions.XYZ
+    storage_names = [
+        point_xyz.storage_type.field(i).name
+        for i in range(point_xyz.storage_type.num_fields)
+    ]
+    assert storage_names == ["x", "y", "z"]
+
+    point_xym = gt.point(dimensions="xym", coord_type="separated").to_pyarrow()
+    assert point_xy.coord_type == gt.CoordType.SEPARATED
+    assert point_xym.dimensions == gt.Dimensions.XYM
+    storage_names = [
+        point_xym.storage_type.field(i).name
+        for i in range(point_xym.storage_type.num_fields)
+    ]
+    assert storage_names == ["x", "y", "m"]
+
+    point_xyzm = gt.point(dimensions="xyzm", coord_type="separated").to_pyarrow()
+    assert point_xy.coord_type == gt.CoordType.SEPARATED
+    assert point_xyzm.dimensions == gt.Dimensions.XYZM
+    storage_names = [
+        point_xyzm.storage_type.field(i).name
+        for i in range(point_xyzm.storage_type.num_fields)
+    ]
+    assert storage_names == ["x", "y", "z", "m"]

--- a/geoarrow-types/tests/test_type_pyarrow.py
+++ b/geoarrow-types/tests/test_type_pyarrow.py
@@ -139,3 +139,27 @@ def test_separated_dimensions():
         for i in range(point_xyzm.storage_type.num_fields)
     ]
     assert storage_names == ["x", "y", "z", "m"]
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        gt.wkt(),
+        gt.large_wkt(),
+        gt.wkb(),
+        gt.large_wkb(),
+        gt.point(),
+        gt.linestring(),
+        gt.polygon(),
+        gt.multipoint(),
+        gt.multilinestring(),
+        gt.multipolygon(),
+    ],
+)
+def test_roundtrip_extension_type_through_storage(spec):
+    extension_type = type_pyarrow.extension_type(spec)
+    serialized = extension_type.__arrow_ext_serialize__()
+    extension_type2 = type_pyarrow._deserialize_storage(
+        extension_type.storage_type, extension_type._extension_name, serialized
+    )
+    assert extension_type2 == extension_type

--- a/geoarrow-types/tests/test_type_pyarrow.py
+++ b/geoarrow-types/tests/test_type_pyarrow.py
@@ -144,19 +144,31 @@ def test_separated_dimensions():
 @pytest.mark.parametrize(
     "spec",
     [
+        # Serialized types
         gt.wkt(),
         gt.large_wkt(),
         gt.wkb(),
         gt.large_wkb(),
+        # Geometry types
         gt.point(),
         gt.linestring(),
         gt.polygon(),
         gt.multipoint(),
         gt.multilinestring(),
         gt.multipolygon(),
+        # All dimensions, separated coords
+        gt.point(dimensions="xy", coord_type="separated"),
+        gt.point(dimensions="xyz", coord_type="separated"),
+        gt.point(dimensions="xym", coord_type="separated"),
+        gt.point(dimensions="xyzm", coord_type="separated"),
+        # All dimensions, interleaved coords
+        gt.point(dimensions="xy", coord_type="interleaved"),
+        gt.point(dimensions="xyz", coord_type="interleaved"),
+        gt.point(dimensions="xym", coord_type="interleaved"),
+        gt.point(dimensions="xyzm", coord_type="interleaved"),
     ],
 )
-def test_roundtrip_extension_type_through_storage(spec):
+def test_roundtrip_extension_type(spec):
     extension_type = type_pyarrow.extension_type(spec)
     serialized = extension_type.__arrow_ext_serialize__()
     extension_type2 = type_pyarrow._deserialize_storage(

--- a/geoarrow-types/tests/test_type_pyarrow.py
+++ b/geoarrow-types/tests/test_type_pyarrow.py
@@ -9,10 +9,16 @@ def test_classes_serialized():
     wkt = gt.wkt().to_pyarrow()
     assert isinstance(wkt, type_pyarrow.WktType)
     assert wkt.encoding == gt.Encoding.WKT
+    assert wkt.geometry_type == gt.GeometryType.GEOMETRY
+    assert wkt.dimensions == gt.Dimensions.UNKNOWN
+    assert wkt.coord_type == gt.CoordType.UNSPECIFIED
 
     wkb = gt.wkb().to_pyarrow()
     assert isinstance(wkb, type_pyarrow.WkbType)
     assert wkb.encoding == gt.Encoding.WKB
+    assert wkb.geometry_type == gt.GeometryType.GEOMETRY
+    assert wkb.dimensions == gt.Dimensions.UNKNOWN
+    assert wkb.coord_type == gt.CoordType.UNSPECIFIED
 
 
 def test_geometry_types():

--- a/geoarrow-types/tests/test_type_spec.py
+++ b/geoarrow-types/tests/test_type_spec.py
@@ -38,12 +38,20 @@ def test_type_spec_extension_name():
 
 
 def test_type_spec_extension_metadata():
-    assert TypeSpec().extension_metadata() == "{}"
+    assert TypeSpec().with_defaults().extension_metadata() == "{}"
     assert (
-        TypeSpec(edge_type=EdgeType.SPHERICAL).extension_metadata()
+        TypeSpec(edge_type=EdgeType.SPHERICAL).with_defaults().extension_metadata()
         == '{"edges": "spherical"}'
     )
-    assert TypeSpec(crs=gt.OGC_CRS84).extension_metadata().startswith('{"crs": {')
+    assert (
+        TypeSpec(crs=gt.OGC_CRS84)
+        .with_defaults()
+        .extension_metadata()
+        .startswith('{"crs": {')
+    )
+
+    with pytest.raises(ValueError, match="Can't compute extension_metadata"):
+        TypeSpec().extension_metadata()
 
 
 def test_type_spec_create():

--- a/geoarrow-types/tests/test_type_spec.py
+++ b/geoarrow-types/tests/test_type_spec.py
@@ -17,6 +17,26 @@ def test_type_spec_repr():
     assert repr(TypeSpec(encoding=Encoding.WKB)) == "TypeSpec(Encoding.WKB)"
 
 
+def test_type_spec_extension_name():
+    assert gt.wkb().extension_name() == "geoarrow.wkb"
+    assert gt.large_wkb().extension_name() == "geoarrow.wkb"
+    assert gt.wkt().extension_name() == "geoarrow.wkt"
+    assert gt.large_wkt().extension_name() == "geoarrow.wkt"
+
+    assert gt.point().extension_name() == "geoarrow.point"
+    assert gt.linestring().extension_name() == "geoarrow.linestring"
+    assert gt.polygon().extension_name() == "geoarrow.polygon"
+    assert gt.multipoint().extension_name() == "geoarrow.multipoint"
+    assert gt.multilinestring().extension_name() == "geoarrow.multilinestring"
+    assert gt.multipolygon().extension_name() == "geoarrow.multipolygon"
+
+    with pytest.raises(ValueError, match="Can't compute extension name for"):
+        TypeSpec().extension_name()
+
+    with pytest.raises(ValueError, match="Can't compute extension name for"):
+        TypeSpec(encoding=Encoding.GEOARROW).extension_name()
+
+
 def test_type_spec_create():
     # From TypeSpec
     spec = TypeSpec()

--- a/geoarrow-types/tests/test_type_spec.py
+++ b/geoarrow-types/tests/test_type_spec.py
@@ -37,6 +37,15 @@ def test_type_spec_extension_name():
         TypeSpec(encoding=Encoding.GEOARROW).extension_name()
 
 
+def test_type_spec_extension_metadata():
+    assert TypeSpec().extension_metadata() == "{}"
+    assert (
+        TypeSpec(edge_type=EdgeType.SPHERICAL).extension_metadata()
+        == '{"edges": "spherical"}'
+    )
+    assert TypeSpec(crs=gt.OGC_CRS84).extension_metadata().startswith('{"crs": {')
+
+
 def test_type_spec_create():
     # From TypeSpec
     spec = TypeSpec()


### PR DESCRIPTION
```python
import geoarrow.types as gt

extension_type = gt.wkb(crs=gt.OGC_CRS84).to_pyarrow()
extension_type.storage_type
#> DataType(binary)

extension_type.crs
#> ProjJsonCrs(OGC:CRS84)

extension_type.to_pandas_dtype()
#> extension<geoarrow.wkb<WkbType>>[pyarrow]

extension_type = gt.point(dimensions="xyz", coord_type="interleaved").to_pyarrow()
extension_type.storage_type
#> FixedSizeListType(fixed_size_list<xyz: double not null>[3])
```