### PR TITLE
refactor(geoarrow-pandas,geoarrow-pyarrow): Use package-specific setup for setuptools_scm

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,7 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Set up Python

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,9 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Generated version files
+_version.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/geoarrow-pandas/pyproject.toml
+++ b/geoarrow-pandas/pyproject.toml
@@ -42,6 +42,7 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 root = ".."
 tag_regex = "geoarrow-pandas-([0-9.]+)"
+git_describe_command = "git describe --long --match='geoarrow-pandas-*'"
 
 [tool.pytest.ini_options]
 consider_namespace_packages = true

--- a/geoarrow-pandas/pyproject.toml
+++ b/geoarrow-pandas/pyproject.toml
@@ -43,6 +43,7 @@ build-backend = "setuptools.build_meta"
 root = ".."
 tag_regex = "geoarrow-pandas-([0-9.]+)"
 git_describe_command = "git describe --long --match='geoarrow-pandas-*'"
+version_file = "src/geoarrow/pandas/_version.py"
 
 [tool.pytest.ini_options]
 consider_namespace_packages = true

--- a/geoarrow-pandas/pyproject.toml
+++ b/geoarrow-pandas/pyproject.toml
@@ -41,6 +41,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 root = ".."
+tag_regex = "geoarrow-pandas-([0-9.]+)"
 
 [tool.pytest.ini_options]
 consider_namespace_packages = true

--- a/geoarrow-pandas/src/geoarrow/pandas/__init__.py
+++ b/geoarrow-pandas/src/geoarrow/pandas/__init__.py
@@ -9,6 +9,8 @@ Examples
 >>> import geoarrow.pandas as _
 """
 
+from geoarrow.types._version import __version__, __version_tuple__  # NOQA: F401
+
 from .lib import (
     GeoArrowAccessor,
     GeoArrowExtensionDtype,

--- a/geoarrow-pandas/tests/test_geoarrow_pandas.py
+++ b/geoarrow-pandas/tests/test_geoarrow_pandas.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 import pandas as pd
@@ -7,6 +9,8 @@ import geoarrow.pyarrow as ga
 from geoarrow.c import lib
 import numpy as np
 
+def test_version():
+    assert re.match(r"^[0-9]+\.[0-9]+\.[0-9]+", gapd.__version__)
 
 def test_dtype_constructor():
     from_pyarrow = gapd.GeoArrowExtensionDtype(ga.point())

--- a/geoarrow-pandas/tests/test_geoarrow_pandas.py
+++ b/geoarrow-pandas/tests/test_geoarrow_pandas.py
@@ -9,8 +9,10 @@ import geoarrow.pyarrow as ga
 from geoarrow.c import lib
 import numpy as np
 
+
 def test_version():
-    assert re.match(r"^[0-9]+\.[0-9]+\.[0-9]+", gapd.__version__)
+    assert re.match(r"^[0-9]+\.[0-9]+", gapd.__version__)
+
 
 def test_dtype_constructor():
     from_pyarrow = gapd.GeoArrowExtensionDtype(ga.point())

--- a/geoarrow-pyarrow/pyproject.toml
+++ b/geoarrow-pyarrow/pyproject.toml
@@ -41,7 +41,8 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 root = ".."
-tag_regex = "geoarrow-pyarrow-([0-9.]+)"
+tag_regex = "geoarrow-pyarrow-([0-9]+.[0-9]+.[0-9]+)"
+git_describe_command = "git describe --long --match='geoarrow-pyarrow-*'"
 
 [tool.pytest.ini_options]
 consider_namespace_packages = true

--- a/geoarrow-pyarrow/pyproject.toml
+++ b/geoarrow-pyarrow/pyproject.toml
@@ -41,6 +41,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 root = ".."
+tag_regex = "geoarrow-pyarrow-([0-9.]+)"
 
 [tool.pytest.ini_options]
 consider_namespace_packages = true

--- a/geoarrow-pyarrow/pyproject.toml
+++ b/geoarrow-pyarrow/pyproject.toml
@@ -43,6 +43,7 @@ build-backend = "setuptools.build_meta"
 root = ".."
 tag_regex = "geoarrow-pyarrow-([0-9]+.[0-9]+.[0-9]+)"
 git_describe_command = "git describe --long --match='geoarrow-pyarrow-*'"
+version_file = "src/geoarrow/pyarrow/_version.py"
 
 [tool.pytest.ini_options]
 consider_namespace_packages = true

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/__init__.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/__init__.py
@@ -7,6 +7,8 @@ Examples
 >>> import geoarrow.pyarrow as ga
 """
 
+from geoarrow.types._version import __version__, __version_tuple__  # NOQA: F401
+
 from geoarrow.c.lib import GeometryType, Dimensions, CoordType, EdgeType, CrsType
 
 from geoarrow.pyarrow._type import (

--- a/geoarrow-pyarrow/tests/test_pyarrow.py
+++ b/geoarrow-pyarrow/tests/test_pyarrow.py
@@ -14,7 +14,7 @@ import geoarrow.pyarrow._array as _array
 
 
 def test_version():
-    assert re.match(r"^[0-9]+\.[0-9]+\.[0-9]+", ga.__version__)
+    assert re.match(r"^[0-9]+\.[0-9]+", ga.__version__)
 
 
 def test_geometry_type_basic():

--- a/geoarrow-pyarrow/tests/test_pyarrow.py
+++ b/geoarrow-pyarrow/tests/test_pyarrow.py
@@ -1,5 +1,6 @@
 import sys
 import json
+import re
 from math import inf
 
 import pyarrow as pa
@@ -10,6 +11,10 @@ import geoarrow.c.lib as lib
 import geoarrow.pyarrow as ga
 import geoarrow.pyarrow._type as _type
 import geoarrow.pyarrow._array as _array
+
+
+def test_version():
+    assert re.match(r"^[0-9]+\.[0-9]+\.[0-9]+", ga.__version__)
 
 
 def test_geometry_type_basic():

--- a/geoarrow-types/pyproject.toml
+++ b/geoarrow-types/pyproject.toml
@@ -42,6 +42,7 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 root = ".."
 tag_regex = "geoarrow-types-([0-9.]+)"
+git_describe_command = "git describe --long --match='geoarrow-types-*'"
 
 [tool.pytest.ini_options]
 consider_namespace_packages = true

--- a/geoarrow-types/pyproject.toml
+++ b/geoarrow-types/pyproject.toml
@@ -43,6 +43,7 @@ build-backend = "setuptools.build_meta"
 root = ".."
 tag_regex = "geoarrow-types-([0-9.]+)"
 git_describe_command = "git describe --long --match='geoarrow-types-*'"
+version_file = "src/geoarrow/types/_version.py"
 
 [tool.pytest.ini_options]
 consider_namespace_packages = true

--- a/geoarrow-types/src/geoarrow/types/__init__.py
+++ b/geoarrow-types/src/geoarrow/types/__init__.py
@@ -1,3 +1,5 @@
+from geoarrow.types._version import __version__, __version_tuple__  # NOQA: F401
+
 from geoarrow.types.constants import (
     Encoding,
     GeometryType,

--- a/geoarrow-types/tests/test_package.py
+++ b/geoarrow-types/tests/test_package.py
@@ -1,0 +1,7 @@
+
+import re
+
+import geoarrow.types as gat
+
+def test_version():
+    assert re.match(r"^[0-9]+\.[0-9]+\.[0-9]+", gat.__version__)

--- a/geoarrow-types/tests/test_package.py
+++ b/geoarrow-types/tests/test_package.py
@@ -1,7 +1,7 @@
-
 import re
 
 import geoarrow.types as gat
 
+
 def test_version():
-    assert re.match(r"^[0-9]+\.[0-9]+\.[0-9]+", gat.__version__)
+    assert re.match(r"^[0-9]+\.[0-9]+", gat.__version__)


### PR DESCRIPTION
This PR updates the setuptools_scm versioning on the three relevant packages to use a package-specific tag format (such that we can release only one of them at a time). It also adds a `__version__` member to the namespace to make it easier to do runtime version checking.