### PR TITLE
feat(geoarrow-types): Implement non-PROJJSON crses and crs_type metadata

### DIFF
--- a/geoarrow-pandas/tests/test_geoarrow_pandas.py
+++ b/geoarrow-pandas/tests/test_geoarrow_pandas.py
@@ -34,7 +34,12 @@ def test_dtype_strings():
     assert dtype2 == dtype
 
     dtype = gapd.GeoArrowExtensionDtype(ga.point().with_crs(ga.OGC_CRS84))
-    assert str(dtype) == 'geoarrow.point{"crs": ' + ga.OGC_CRS84.to_json() + "}"
+    assert (
+        str(dtype)
+        == 'geoarrow.point{"crs": '
+        + ga.OGC_CRS84.to_json()
+        + ', "crs_type": "projjson"}'
+    )
     dtype2 = gapd.GeoArrowExtensionDtype.construct_from_string(str(dtype))
     assert dtype2 == dtype
 

--- a/geoarrow-pyarrow/tests/test_compute.py
+++ b/geoarrow-pyarrow/tests/test_compute.py
@@ -350,6 +350,9 @@ def test_with_crs():
     assert isinstance(crsified.type, ga.WktType)
     assert crsified.type.crs.to_json_dict() == types.OGC_CRS84.to_json_dict()
 
+    crsified2 = _compute.with_crs(crsified, "OGC:CRS84")
+    assert repr(crsified2.type.crs) == "StringCrs(OGC:CRS84)"
+
     crsnope = _compute.with_crs(crsified, None)
     assert crsnope.type.crs is None
 

--- a/geoarrow-pyarrow/tests/test_pyarrow.py
+++ b/geoarrow-pyarrow/tests/test_pyarrow.py
@@ -48,17 +48,19 @@ def test_geometry_type_with():
     type_spherical = type_obj.with_edge_type(ga.EdgeType.SPHERICAL)
     assert type_spherical.edge_type == ga.EdgeType.SPHERICAL
 
-    # Explicit type
     type_crs = type_obj.with_crs(types.OGC_CRS84)
     assert type_crs.crs == types.OGC_CRS84
+
+    type_crs = type_obj.with_crs("OGC:CRS84")
+    assert repr(type_crs.crs) == "StringCrs(OGC:CRS84)"
 
 
 def test_type_with_crs_pyproj():
     pyproj = pytest.importorskip("pyproj")
     type_obj = ga.wkb()
 
-    # Implicit type
     type_crs = type_obj.with_crs(pyproj.CRS("EPSG:32620"))
+    assert isinstance(type_crs.crs, pyproj.CRS)
     crs_dict = type_crs.crs.to_json_dict()
     assert crs_dict["id"]["code"] == 32620
 

--- a/geoarrow-types/src/geoarrow/types/crs.py
+++ b/geoarrow-types/src/geoarrow/types/crs.py
@@ -305,8 +305,12 @@ def create(obj) -> Optional[Crs]:
         return None
     elif hasattr(obj, "to_json_dict"):
         return obj
-    else:
+    elif isinstance(obj, dict):
         return ProjJsonCrs(obj)
+    elif isinstance(obj, (str, bytes)):
+        return StringCrs(obj)
+    else:
+        raise ValueError(f"Can't create geoarrow.types.Crs from {obj}")
 
 
 def _coalesce2(value, default):

--- a/geoarrow-types/src/geoarrow/types/crs.py
+++ b/geoarrow-types/src/geoarrow/types/crs.py
@@ -102,6 +102,14 @@ class ProjJsonCrs(Crs):
 
         return deepcopy(self._obj)
 
+    def to_wkt(self) -> str:
+        # This could in theory be written to not use pyproj; however, the
+        # main purpose of this method is to enable pyproj.CRS(self) so it
+        # may not matter.
+        import pyproj
+
+        return pyproj.CRS(self.to_json_dict()).to_wkt()
+
     def __repr__(self) -> str:
         try:
             crs_dict = self.to_json_dict()
@@ -161,8 +169,17 @@ class StringCrs(Crs):
     def to_json_dict(self) -> Mapping:
         return json.loads(self.to_json())
 
+    def to_wkt(self) -> str:
+        import pyproj
+
+        crs_repr = self.__geoarrow_crs_json_values__()["crs"]
+        return pyproj.CRS(crs_repr).to_wkt()
+
+    def __repr__(self) -> str:
+        crs_repr = self.__geoarrow_crs_json_values__()["crs"]
+        return f"StringCrs({crs_repr})"
+
     def _try_parse_json_object(self) -> Optional[dict]:
-        # If this is valid JSON and is a dictionary, assume it's PROJJSON
         try:
             obj = json.loads(self._crs)
             if isinstance(obj, dict):

--- a/geoarrow-types/tests/test_crs.py
+++ b/geoarrow-types/tests/test_crs.py
@@ -38,6 +38,33 @@ def test_projjson_crs_repr():
     assert repr(crs_invalid_json) == 'ProjJsonCrs({"this is not valid json)'
 
 
+def test_string_crs():
+    crs_obj = crs.StringCrs("arbitrary string")
+    assert crs_obj.__geoarrow_crs_json_values__() == {"crs": "arbitrary string"}
+    assert repr(crs_obj) == "StringCrs(arbitrary string)"
+
+
+def test_string_crs_quoted_json_string():
+    crs_obj = crs.StringCrs('"this is json"')
+    assert crs_obj.__geoarrow_crs_json_values__() == {"crs": "this is json"}
+    assert repr(crs_obj) == "StringCrs(this is json)"
+
+
+def test_string_crs_json_object():
+    crs_obj = crs.StringCrs('{"valid": "object"}')
+    assert crs_obj.to_json() == '{"valid": "object"}'
+    assert crs_obj.to_json_dict() == {"valid": "object"}
+
+
+def test_string_crs_pyproj():
+    pyproj = pytest.importorskip("pyproj")
+
+    crs_obj = crs.StringCrs("OGC:CRS84")
+    assert crs_obj.to_json_dict() == pyproj.CRS("OGC:CRS84").to_json_dict()
+    assert crs_obj.to_json() == pyproj.CRS("OGC:CRS84").to_json()
+    assert crs_obj.to_wkt() == pyproj.CRS("OGC:CRS84").to_wkt()
+
+
 def test_crs_coalesce():
     assert crs._coalesce2(crs.UNSPECIFIED, crs.OGC_CRS84) is crs.OGC_CRS84
     assert crs._coalesce2(None, crs.OGC_CRS84) is None


### PR DESCRIPTION
This PR implements CRS values that are not JSON objects in the extension metadata (while preserving the PROJJSON-ness of CRSes that are declared in this way). It also improves interoperability with pyproj by adding the .to_wkt() attribute on the ProjJsonCrs and the StringCrs (since pyproj uses this internally to construct CRSes from arbitrary objects).