### PR TITLE
feat(geoarrow-types): Add support for geometry/collection union

### DIFF
--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
@@ -180,11 +180,12 @@ def infer_type_common(obj, coord_type=None, promote_multi=False, _geometry_types
     if promote_multi and geometry_type.value in (1, 2, 3):
         geometry_type = GeometryType(geometry_type.value + 3)
 
-    spec = TypeSpec.coalesce(
-        type_spec(Encoding.GEOARROW, dims, geometry_type, coord_type=coord_type),
-        obj.type.spec,
-    ).canonicalize()
+    if geometry_type == GeometryType.GEOMETRY:
+        spec = type_spec(Encoding.WKB)
+    else:
+        spec = type_spec(Encoding.GEOARROW, dims, geometry_type, coord_type=coord_type)
 
+    spec = TypeSpec.coalesce(spec, obj.type.spec).canonicalize()
     return _type.extension_type(spec)
 
 

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_type.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_type.py
@@ -161,4 +161,11 @@ def geometry_type_common(
 
     specs = [t.spec for t in type_objects]
     spec = types.TypeSpec.common(*specs).canonicalize()
+
+    if (
+        spec.encoding == types.Encoding.GEOARROW
+        and spec.geometry_type == types.GeometryType.GEOMETRY
+    ):
+        spec = types.TypeSpec.coalesce(types.wkb(), spec)
+
     return extension_type(spec)

--- a/geoarrow-types/src/geoarrow/types/type_pyarrow.py
+++ b/geoarrow-types/src/geoarrow/types/type_pyarrow.py
@@ -553,7 +553,7 @@ def _parse_storage(storage_type):
         parsed_children = tuple(
             _parse_storage(storage_type.field(i).type)[0] for i in range(n_fields)
         )
-        return ["dense_union", (names, parsed_children)]
+        return [("dense_union", (names, parsed_children))]
     elif isinstance(storage_type, pa.StructType):
         n_fields = storage_type.num_fields
         names = tuple(storage_type.field(i).name for i in range(n_fields))

--- a/geoarrow-types/src/geoarrow/types/type_pyarrow.py
+++ b/geoarrow-types/src/geoarrow/types/type_pyarrow.py
@@ -468,14 +468,14 @@ def register_extension_types(lazy: bool = True) -> None:
     all_types = [
         type_spec(Encoding.WKT).to_pyarrow(),
         type_spec(Encoding.WKB).to_pyarrow(),
-        # type_spec(Encoding.GEOARROW, GeometryType.GEOMETRY).to_pyarrow(),
+        type_spec(Encoding.GEOARROW, GeometryType.GEOMETRY).to_pyarrow(),
         type_spec(Encoding.GEOARROW, GeometryType.POINT).to_pyarrow(),
         type_spec(Encoding.GEOARROW, GeometryType.LINESTRING).to_pyarrow(),
         type_spec(Encoding.GEOARROW, GeometryType.POLYGON).to_pyarrow(),
         type_spec(Encoding.GEOARROW, GeometryType.MULTIPOINT).to_pyarrow(),
         type_spec(Encoding.GEOARROW, GeometryType.MULTILINESTRING).to_pyarrow(),
         type_spec(Encoding.GEOARROW, GeometryType.MULTIPOLYGON).to_pyarrow(),
-        # type_spec(Encoding.GEOARROW, GeometryType.GEOMETRYCOLLECTION).to_pyarrow(),
+        type_spec(Encoding.GEOARROW, GeometryType.GEOMETRYCOLLECTION).to_pyarrow(),
     ]
 
     n_registered = 0

--- a/geoarrow-types/src/geoarrow/types/type_pyarrow.py
+++ b/geoarrow-types/src/geoarrow/types/type_pyarrow.py
@@ -797,6 +797,12 @@ def _generate_storage_types():
                 storage_type = _nested_type(coord, names)
                 all_storage_types[key] = storage_type
 
+    # Circular logic!
+    # for coord_type in all_coord_types:
+    #     all_coord_types[(GeometryType.GEOMETRY, coord_type, Dimensions.UNKNOWN)] = (
+    #         _generate_union_storage(coord_type=coord_type)
+    #     )
+
     return all_storage_types
 
 

--- a/geoarrow-types/src/geoarrow/types/type_pyarrow.py
+++ b/geoarrow-types/src/geoarrow/types/type_pyarrow.py
@@ -880,9 +880,9 @@ def _add_union_types_to_native_storage_types():
 
     for coord_type in ALL_COORD_TYPES:
         for dimension in ALL_DIMENSIONS:
-            _NATIVE_STORAGE_TYPES[(GeometryType.GEOMETRY, coord_type, dimension)] = (
-                _generate_union_storage(coord_type=coord_type, dimensions=[dimension])
-            )
+            _NATIVE_STORAGE_TYPES[
+                (GeometryType.GEOMETRY, coord_type, dimension)
+            ] = _generate_union_storage(coord_type=coord_type, dimensions=[dimension])
 
         # With unknown dimensions, we reigster the massive catch-all union
         _NATIVE_STORAGE_TYPES[

--- a/geoarrow-types/src/geoarrow/types/type_pyarrow.py
+++ b/geoarrow-types/src/geoarrow/types/type_pyarrow.py
@@ -594,9 +594,12 @@ def _deserialize_storage(storage_type, extension_name=None, extension_metadata=N
     spec = _SPEC_FROM_TYPE_NESTING[parsed_type_names]
     spec = TypeSpec.from_extension_metadata(extension_metadata).with_defaults(spec)
 
-    # If this is a serialized type, we don't need to infer any more information
-    # from the storage type.
-    if spec.encoding.is_serialized():
+    # If this is a serialized type or a union, we don't need to infer any more information
+    # from the storage type (because we don't currently validate union types).
+    if spec.encoding.is_serialized() or spec.geometry_type in (
+        GeometryType.GEOMETRY,
+        GeometryType.GEOMETRYCOLLECTION,
+    ):
         if extension_name is not None and spec.extension_name() != extension_name:
             raise ValueError(f"Can't interpret {storage_type} as {extension_name}")
 
@@ -907,11 +910,13 @@ _EXTENSION_CLASSES = {
     "geoarrow.wkb": WkbType,
     "geoarrow.wkt": WktType,
     "geoarrow.point": PointType,
+    "geoarrow.geometry": GeometryUnionType,
     "geoarrow.linestring": LinestringType,
     "geoarrow.polygon": PolygonType,
     "geoarrow.multipoint": MultiPointType,
     "geoarrow.multilinestring": MultiLinestringType,
     "geoarrow.multipolygon": MultiPolygonType,
+    "geoarrow.geometrycollection": GeometryCollectionUnionType,
 }
 
 _SERIALIZED_STORAGE_TYPES = {

--- a/geoarrow-types/src/geoarrow/types/type_pyarrow.py
+++ b/geoarrow-types/src/geoarrow/types/type_pyarrow.py
@@ -890,9 +890,9 @@ def _add_union_types_to_native_storage_types():
         # We register the same type for every dimensions (including unknown)
         # because the Geometry union does not currently disambiguate them
         for dimension in Dimensions.__members__.values():
-            _NATIVE_STORAGE_TYPES[(GeometryType.GEOMETRY, coord_type, dimension)] = (
-                _generate_union_storage(coord_type=coord_type)
-            )
+            _NATIVE_STORAGE_TYPES[
+                (GeometryType.GEOMETRY, coord_type, dimension)
+            ] = _generate_union_storage(coord_type=coord_type)
 
     for coord_type in [CoordType.SEPARATED, CoordType.INTERLEAVED]:
         for dimension in [

--- a/geoarrow-types/src/geoarrow/types/type_pyarrow.py
+++ b/geoarrow-types/src/geoarrow/types/type_pyarrow.py
@@ -224,7 +224,7 @@ class GeometryExtensionType(pa.ExtensionType):
         >>> ga.linestring().with_edge_type(ga.EdgeType.SPHERICAL)
         LinestringType(spherical geoarrow.linestring)
         """
-        spec = type_spec(edge_type=edge_type, crs=self.crs)
+        spec = type_spec(edge_type=edge_type)
         spec = TypeSpec.coalesce(spec, self.spec).canonicalize()
         return extension_type(spec)
 

--- a/geoarrow-types/src/geoarrow/types/type_pyarrow.py
+++ b/geoarrow-types/src/geoarrow/types/type_pyarrow.py
@@ -886,21 +886,26 @@ def _generate_union_type_id_mapping():
 def _add_union_types_to_native_storage_types():
     global _NATIVE_STORAGE_TYPES
 
-    for coord_type in [CoordType.SEPARATED, CoordType.INTERLEAVED]:
-        # We register the same type for every dimensions (including unknown)
-        # because the Geometry union does not currently disambiguate them
-        for dimension in Dimensions.__members__.values():
-            _NATIVE_STORAGE_TYPES[
-                (GeometryType.GEOMETRY, coord_type, dimension)
-            ] = _generate_union_storage(coord_type=coord_type)
+    all_dimensions = [
+        Dimensions.XY,
+        Dimensions.XYZ,
+        Dimensions.XYM,
+        Dimensions.XYZM,
+    ]
 
     for coord_type in [CoordType.SEPARATED, CoordType.INTERLEAVED]:
-        for dimension in [
-            Dimensions.XY,
-            Dimensions.XYZ,
-            Dimensions.XYM,
-            Dimensions.XYZM,
-        ]:
+        for dimension in all_dimensions:
+            _NATIVE_STORAGE_TYPES[(GeometryType.GEOMETRY, coord_type, dimension)] = (
+                _generate_union_storage(coord_type=coord_type, dimensions=[dimension])
+            )
+
+        # With unknown dimensions, we reigster the massive catch-all union
+        _NATIVE_STORAGE_TYPES[(GeometryType.GEOMETRY, coord_type, Dimensions.UNKNOWN)] = (
+            _generate_union_storage(coord_type=coord_type)
+        )
+
+    for coord_type in [CoordType.SEPARATED, CoordType.INTERLEAVED]:
+        for dimension in all_dimensions:
             _NATIVE_STORAGE_TYPES[
                 (GeometryType.GEOMETRYCOLLECTION, coord_type, dimension)
             ] = _generate_union_collection_storage(dimension, coord_type)

--- a/geoarrow-types/src/geoarrow/types/type_spec.py
+++ b/geoarrow-types/src/geoarrow/types/type_spec.py
@@ -604,12 +604,14 @@ _SERIALIZED_EXT_NAMES = {
 }
 
 _GEOARROW_EXT_NAMES = {
+    GeometryType.GEOMETRY: "geoarrow.geometry",
     GeometryType.POINT: "geoarrow.point",
     GeometryType.LINESTRING: "geoarrow.linestring",
     GeometryType.POLYGON: "geoarrow.polygon",
     GeometryType.MULTIPOINT: "geoarrow.multipoint",
     GeometryType.MULTILINESTRING: "geoarrow.multilinestring",
     GeometryType.MULTIPOLYGON: "geoarrow.multipolygon",
+    GeometryType.GEOMETRYCOLLECTION: "geoarrow.geometrycollection",
 }
 
 _GEOMETRY_TYPE_FROM_EXT = {v: k for k, v in _GEOARROW_EXT_NAMES.items()}

--- a/geoarrow-types/src/geoarrow/types/type_spec.py
+++ b/geoarrow-types/src/geoarrow/types/type_spec.py
@@ -132,13 +132,10 @@ class TypeSpec(NamedTuple):
 
         If this type specification represents a serialized type, ensure
         that the dimensions are UNKNOWN, the geometry type is GEOMETRY,
-        and the coord type is UNSPECIFIED. Conversely, when geometry
-        type is UNKNOWN, the geometry type can't be guessed and we
-        need to set the encoding to a serialized type.
+        and the coord type is UNSPECIFIED.
 
-        These ensure that when a type
-        implementation needs to construct a concrete type that its
-        components are represented consistently.
+        These ensure that when a type implementation needs to construct a
+        concrete type that its components are represented consistently.
         """
         if self.encoding.is_serialized():
             return self.override(
@@ -146,8 +143,6 @@ class TypeSpec(NamedTuple):
                 dimensions=Dimensions.UNKNOWN,
                 coord_type=CoordType.UNSPECIFIED,
             )
-        elif self.geometry_type == GeometryType.GEOMETRY:
-            return self.override(encoding=Encoding.WKB).canonicalize()
         else:
             return self
 

--- a/geoarrow-types/tests/test_type_pyarrow.py
+++ b/geoarrow-types/tests/test_type_pyarrow.py
@@ -285,6 +285,22 @@ def test_deserialize_infer_dimensions_interleaved():
         )
 
 
+def test_geometry_union_type():
+    geometry = gt.type_spec(gt.Encoding.GEOARROW, gt.GeometryType.GEOMETRY).to_pyarrow()
+    assert isinstance(geometry, type_pyarrow.GeometryUnionType)
+    assert geometry.encoding == gt.Encoding.GEOARROW
+    assert geometry.geometry_type == gt.GeometryType.GEOMETRY
+
+
+def test_geometry_collection_union_type():
+    geometry = gt.type_spec(
+        gt.Encoding.GEOARROW, gt.GeometryType.GEOMETRYCOLLECTION
+    ).to_pyarrow()
+    assert isinstance(geometry, type_pyarrow.GeometryCollectionUnionType)
+    assert geometry.encoding == gt.Encoding.GEOARROW
+    assert geometry.geometry_type == gt.GeometryType.GEOMETRYCOLLECTION
+
+
 def test_point_array_from_geobuffers():
     pa_type = gt.point(dimensions=gt.Dimensions.XYZM).to_pyarrow()
     arr = pa_type.from_geobuffers(
@@ -417,6 +433,9 @@ def test_multipolygon_array_from_geobuffers():
         gt.point(dimensions="xyz", coord_type="interleaved"),
         gt.point(dimensions="xym", coord_type="interleaved"),
         gt.point(dimensions="xyzm", coord_type="interleaved"),
+        # Union types
+        gt.type_spec(gt.Encoding.GEOARROW, gt.GeometryType.GEOMETRY),
+        gt.type_spec(gt.Encoding.GEOARROW, gt.GeometryType.GEOMETRYCOLLECTION),
     ],
 )
 def test_roundtrip_extension_type(spec):


### PR DESCRIPTION
It's a monster of a union, but it does work:

```python
import geoarrow.types as gt
import geoarrow.pyarrow as ga

ga.extension_type(gt.type_spec(gt.Encoding.GEOARROW, gt.GeometryType.GEOMETRY))
#> GeometryUnionType(geoarrow.geometry)
```

This PR adds enough support such that pyarrow should be able to import and export a geometry array produced by geoarrow-rs, and enough support that people can experiment with the type if they want to (but I'll leave other functionality up to future PRs 🙂 ).