### PR TITLE
chore(geoarrow-types): Test against Python 3.7 and Python 3.8

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -90,14 +90,14 @@ jobs:
       # without this modification)
       - name: Patch pyproject.toml
         run:
-          pushd geoarrow-types
+          cd geoarrow-types
           sed -i.bak '/^version_file/d' pyproject.toml
 
       - name: Install (geoarrow-types)
         run: |
           pip install --upgrade setuptools
-          pushd geoarrow-types
-          pip install -e ".[test]"
+          cd geoarrow-types
+          pip install ".[test]"
 
       - name: Run tests (geoarrow-types)
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,6 +75,10 @@ jobs:
           cd geoarrow-pandas
           pytest --pyargs geoarrow.pandas --doctest-modules --import-mode=importlib
 
+  # This is a test of geoarrow-types on Python 3.7 (which implies pyarrow 12
+  # since this is the last supported version there). Python 3.7 is still the
+  # runtime available on some hosted platforms (e.g., it is the minimum required
+  # version for apache-sedona Python)
   oldest-supported:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,7 +89,7 @@ jobs:
       # (it can still be installed on Python 3.7, it just can't be built there
       # without this modification)
       - name: Patch pyproject.toml
-        run:
+        run: |
           cd geoarrow-types
           sed -i.bak '/^version_file/d' pyproject.toml
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8']
+        python-version: ['3.8']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Check git setup
         run: |
-          git fetch origin --tags
+          git config --global --add safe.directory "$(pwd)"
           git describe --long --match='geoarrow-types-*'
 
       # setuptools_scm available for Python 3.7 does not support version_file

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v4
@@ -75,25 +75,27 @@ jobs:
           cd geoarrow-pandas
           pytest --pyargs geoarrow.pandas --doctest-modules --import-mode=importlib
 
-  python-old:
+  oldest-supported:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ['3.8']
+    container:
+      image: python:3.7
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '${{ matrix.python-version }}'
-          cache: 'pip'
+
+      # setuptools_scm available for Python 3.7 does not support version_file
+      # (it can still be installed on Python 3.7, it just can't be built there
+      # without this modification)
+      - name: Patch pyproject.toml
+        run:
+          pushd geoarrow-types
+          sed -i.bak '/^version_file/d' pyproject.toml
 
       - name: Install (geoarrow-types)
         run: |
+          pip install --upgrade setuptools
           pushd geoarrow-types
           pip install -e ".[test]"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Install (geoarrow-types)
         run: |
-          pip install --upgrade setuptools
+          pip install --upgrade setuptools setuptools_scm
           cd geoarrow-types
           pip install ".[test]"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,6 +75,32 @@ jobs:
           cd geoarrow-pandas
           pytest --pyargs geoarrow.pandas --doctest-modules --import-mode=importlib
 
+  python-old:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.7', '3.8']
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+
+      - name: Install (geoarrow-types)
+        run: |
+          pushd geoarrow-types
+          pip install -e ".[test]"
+
+      - name: Run tests (geoarrow-types)
+        run: |
+          pytest geoarrow-types/tests -v -s
+
   coverage:
     needs: [test]
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,7 +98,8 @@ jobs:
         run: |
           cd geoarrow-types
           sed -i.bak '/^version_file/d' pyproject.toml
-          echo '__version__ = __version_tuple__ = None' > src/geoarrow/types/_version.py
+          echo '__version__ = "0.0.0"' > src/geoarrow/types/_version.py
+          echo '__version_tuple__ = (0, 0, 0)' >> src/geoarrow/types/_version.py
 
       - name: Install (geoarrow-types)
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,6 +98,7 @@ jobs:
         run: |
           cd geoarrow-types
           sed -i.bak '/^version_file/d' pyproject.toml
+          echo '__version__ = __version_tuple__ = None' > src/geoarrow/types/_version.py
 
       - name: Install (geoarrow-types)
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,6 +84,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          tags: true
+
+      - name: Check git setup
+        run: |
+          git fetch origin --tags
+          git describe --long --match='geoarrow-types-*'
 
       # setuptools_scm available for Python 3.7 does not support version_file
       # (it can still be installed on Python 3.7, it just can't be built there

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.13'
+          python-version: '${{ matrix.python-version }}'
           cache: 'pip'
 
       - name: Install (geoarrow-types)

--- a/geoarrow-types/pyproject.toml
+++ b/geoarrow-types/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = ["version"]
 description = ""
 authors = [{name = "Dewey Dunnington", email = "dewey@dunnington.ca"}]
 license = {text = "Apache-2.0"}
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 dependencies = []
 
 [project.optional-dependencies]

--- a/geoarrow-types/pyproject.toml
+++ b/geoarrow-types/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.7"
 dependencies = []
 
 [project.optional-dependencies]
-test = ["pytest", "pyarrow"]
+test = ["pytest", "pyarrow", "numpy"]
 
 [project.urls]
 homepage = "https://geoarrow.org"

--- a/geoarrow-types/pyproject.toml
+++ b/geoarrow-types/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.7"
 dependencies = []
 
 [project.optional-dependencies]
-test = ["pytest", "pyarrow", "numpy"]
+test = ["pytest", "pyarrow >= 12", "numpy"]
 
 [project.urls]
 homepage = "https://geoarrow.org"

--- a/geoarrow-types/src/geoarrow/types/crs.py
+++ b/geoarrow-types/src/geoarrow/types/crs.py
@@ -1,6 +1,12 @@
 from copy import deepcopy
 import json
-from typing import Union, Mapping, Protocol, Optional
+from typing import Union, Mapping, Optional
+
+try:
+    from typing import Protocol
+except ImportError:
+    class Protocol:
+        pass
 
 
 class Crs(Protocol):

--- a/geoarrow-types/src/geoarrow/types/crs.py
+++ b/geoarrow-types/src/geoarrow/types/crs.py
@@ -5,6 +5,7 @@ from typing import Union, Mapping, Optional
 try:
     from typing import Protocol
 except ImportError:
+
     class Protocol:
         pass
 

--- a/geoarrow-types/tests/test_type_pyarrow.py
+++ b/geoarrow-types/tests/test_type_pyarrow.py
@@ -7,6 +7,10 @@ from geoarrow.types import type_pyarrow
 
 
 def test_wrap_array_non_exact():
+    pa_version_tuple = tuple(int(component) for component in pa.__version__.split("."))
+    if pa_version_tuple < (14,):
+        pytest.skip("wrap_array with non-exact type requires pyarrow >= 14")
+
     from pyarrow import compute as pc
 
     storage = pc.make_struct(
@@ -448,6 +452,10 @@ def test_roundtrip_extension_type(spec):
 
 
 def test_register_extension_type():
+    pa_version_tuple = tuple(int(component) for component in pa.__version__.split("."))
+    if pa_version_tuple < (14,):
+        pytest.skip("Can't test extension type registration pyarrow < 14")
+
     with type_pyarrow.registered_extension_types():
         schema_capsule = gt.point().to_pyarrow().__arrow_c_schema__()
         pa_type = pa.DataType._import_from_c_capsule(schema_capsule)


### PR DESCRIPTION
This PR tests geoarrow-types against older Python versions. The tests already passed for Python 3.8, and with minimal changes we can support 3.7. Python 3.7 is the version of Python available on some hosted runtimes and is the minimum supported version for Sedona (which mostly just makes configuring their CI hard if we don't support Python 3.7).