### PR TITLE
fix: Enable build against geoarrow-c 0.2

### DIFF
--- a/geoarrow-pandas/src/geoarrow/pandas/lib.py
+++ b/geoarrow-pandas/src/geoarrow/pandas/lib.py
@@ -507,18 +507,18 @@ class GeoArrowAccessor:
         """See :func:`geoarrow.pyarrow.box`"""
         array_or_chunked = _ga.box(self._obj)
         if isinstance(array_or_chunked, _pa.ChunkedArray):
-            flattened = [chunk.flatten() for chunk in array_or_chunked.chunks]
+            flattened = [chunk.storage.flatten() for chunk in array_or_chunked.chunks]
             seriesish = [
                 _pa.chunked_array(item, _pa.float64()) for item in zip(*flattened)
             ]
         else:
-            seriesish = array_or_chunked.flatten()
+            seriesish = array_or_chunked.storage.flatten()
 
         return _pd.DataFrame(
             {
                 "xmin": seriesish[0],
-                "xmax": seriesish[1],
-                "ymin": seriesish[2],
+                "xmax": seriesish[2],
+                "ymin": seriesish[1],
                 "ymax": seriesish[3],
             },
             index=self._obj.index,

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
@@ -78,8 +78,18 @@ class GeometryExtensionArray(pa.ExtensionArray):
         return f"{type_name}:{repr(self.type)}[{len(self)}]\n{items_str}".strip()
 
 
+class BoxArray(GeometryExtensionArray):
+    def __repr__(self):
+        type_name = type(self).__name__
+        items_str = "\n".join(repr(item.bounds) for item in self)
+        return f"{type_name}:{repr(self.type)}[{len(self)}]\n{items_str}".strip()
+
+
 def array_cls_from_name(name):
-    return GeometryExtensionArray
+    if name == "geoarrow.box":
+        return BoxArray
+    else:
+        return GeometryExtensionArray
 
 
 # Inject array_cls_from_name exactly once to avoid circular import

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
@@ -101,7 +101,7 @@ def array(obj, type_=None, *args, **kwargs) -> GeometryExtensionArray:
     GeometryExtensionArray:WktType(geoarrow.wkt)[1]
     <POINT (0 1)>
     >>> ga.as_geoarrow(["POINT (0 1)"])
-    PointArray:PointType(geoarrow.point)[1]
+    GeometryExtensionArray:PointType(geoarrow.point)[1]
     <POINT (0 1)>
     """
     # Convert GeoPandas to WKB

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
@@ -78,49 +78,8 @@ class GeometryExtensionArray(pa.ExtensionArray):
         return f"{type_name}:{repr(self.type)}[{len(self)}]\n{items_str}".strip()
 
 
-class PointArray(GeometryExtensionArray):
-    pass
-
-
-class LinestringArray(GeometryExtensionArray):
-    pass
-
-
-class PolygonArray(GeometryExtensionArray):
-    pass
-
-
-class MultiPointArray(GeometryExtensionArray):
-    pass
-
-
-class MultiLinestringArray(GeometryExtensionArray):
-    pass
-
-
-class MultiPolygonArray(GeometryExtensionArray):
-    pass
-
-
 def array_cls_from_name(name):
-    if name == "geoarrow.wkb":
-        return GeometryExtensionArray
-    elif name == "geoarrow.wkt":
-        return GeometryExtensionArray
-    elif name == "geoarrow.point":
-        return PointArray
-    elif name == "geoarrow.linestring":
-        return LinestringArray
-    elif name == "geoarrow.polygon":
-        return PolygonArray
-    elif name == "geoarrow.multipoint":
-        return MultiPointArray
-    elif name == "geoarrow.multilinestring":
-        return MultiLinestringArray
-    elif name == "geoarrow.multipolygon":
-        return MultiPolygonArray
-    else:
-        raise ValueError(f'Expected valid extension name but got "{name}"')
+    return GeometryExtensionArray
 
 
 # Inject array_cls_from_name exactly once to avoid circular import

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
@@ -251,7 +251,7 @@ def as_geoarrow(obj, type=None, coord_type=None, promote_multi=False):
 
     >>> import geoarrow.pyarrow as ga
     >>> ga.as_geoarrow(["POINT (0 1)", "MULTIPOINT Z (0 1 2, 4 5 6)"])
-    MultiPointArray:MultiPointType(geoarrow.multipoint_z)[2]
+    GeometryExtensionArray:MultiPointType(geoarrow.multipoint_z)[2]
     <MULTIPOINT Z (0 1 nan)>
     <MULTIPOINT Z (0 1 2, 4 5 6)>
     """
@@ -307,7 +307,7 @@ def make_point(x, y, z=None, m=None, crs=None):
 
     >>> import geoarrow.pyarrow as ga
     >>> ga.make_point([1, 2, 3], [4, 5, 6])
-    PointArray:PointType(geoarrow.point)[3]
+    GeometryExtensionArray:PointType(geoarrow.point)[3]
     <POINT (1 4)>
     <POINT (2 5)>
     <POINT (3 6)>
@@ -351,7 +351,7 @@ def box(obj):
 
     >>> import geoarrow.pyarrow as ga
     >>> ga.box(["LINESTRING (0 10, 34 -1)"]).type
-    StructType(struct<xmin: double, xmax: double, ymin: double, ymax: double>)
+    BoxType(geoarrow.box)
     >>> print(str(ga.box(["LINESTRING (0 10, 34 -1)"])))
     -- is_valid: all not null
     -- child 0 type: double
@@ -360,11 +360,11 @@ def box(obj):
       ]
     -- child 1 type: double
       [
-        34
+        -1
       ]
     -- child 2 type: double
       [
-        -1
+        34
       ]
     -- child 3 type: double
       [
@@ -418,7 +418,7 @@ def box_agg(obj):
 
     >>> import geoarrow.pyarrow as ga
     >>> ga.box_agg(["POINT (0 10)", "POINT (34 -1)"])
-    <pyarrow.StructScalar: [('xmin', 0.0), ('xmax', 34.0), ('ymin', -1.0), ('ymax', 10.0)]>
+    BoxScalar({'xmin': 0.0, 'ymin': -1.0, 'xmax': 34.0, 'ymax': 10.0})
     """
 
     obj = obj_as_array_or_chunked(obj)
@@ -496,7 +496,7 @@ def with_coord_type(obj, coord_type):
 
     >>> import geoarrow.pyarrow as ga
     >>> ga.with_coord_type(["POINT (0 1)"], ga.CoordType.INTERLEAVED)
-    PointArray:PointType(interleaved geoarrow.point)[1]
+    GeometryExtensionArray:PointType(interleaved geoarrow.point)[1]
     <POINT (0 1)>
     """
     return as_geoarrow(obj, coord_type=coord_type)
@@ -538,10 +538,10 @@ def with_dimensions(obj, dimensions):
 
     >>> import geoarrow.pyarrow as ga
     >>> ga.with_dimensions(["POINT (0 1)"], ga.Dimensions.XYZM)
-    PointArray:PointType(geoarrow.point_zm)[1]
+    GeometryExtensionArray:PointType(geoarrow.point_zm)[1]
     <POINT ZM (0 1 nan nan)>
     >>> ga.with_dimensions(["POINT ZM (0 1 2 3)"], ga.Dimensions.XY)
-    PointArray:PointType(geoarrow.point)[1]
+    GeometryExtensionArray:PointType(geoarrow.point)[1]
     <POINT (0 1)>
     """
     obj = as_geoarrow(obj)
@@ -558,13 +558,13 @@ def with_geometry_type(obj, geometry_type):
 
     >>> import geoarrow.pyarrow as ga
     >>> ga.with_geometry_type(["POINT (0 1)"], ga.GeometryType.MULTIPOINT)
-    MultiPointArray:MultiPointType(geoarrow.multipoint)[1]
+    GeometryExtensionArray:MultiPointType(geoarrow.multipoint)[1]
     <MULTIPOINT (0 1)>
     >>> ga.with_geometry_type(["MULTIPOINT (0 1)"], ga.GeometryType.POINT)
-    PointArray:PointType(geoarrow.point)[1]
+    GeometryExtensionArray:PointType(geoarrow.point)[1]
     <POINT (0 1)>
     >>> ga.with_geometry_type(["LINESTRING EMPTY", "POINT (0 1)"], ga.GeometryType.POINT)
-    PointArray:PointType(geoarrow.point)[2]
+    GeometryExtensionArray:PointType(geoarrow.point)[2]
     <POINT (nan nan)>
     <POINT (0 1)>
     >>> ga.with_geometry_type(["MULTIPOINT (0 1, 2 3)"], ga.GeometryType.POINT)

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
@@ -72,49 +72,13 @@ class WkbScalar(GeometryExtensionScalar):
         return self.value.as_py()
 
 
-class PointScalar(GeometryExtensionScalar):
-    pass
-
-
-class LinestringScalar(GeometryExtensionScalar):
-    pass
-
-
-class PolygonScalar(GeometryExtensionScalar):
-    pass
-
-
-class MultiPointScalar(GeometryExtensionScalar):
-    pass
-
-
-class MultiLinestringScalar(GeometryExtensionScalar):
-    pass
-
-
-class MultiPolygonScalar(GeometryExtensionScalar):
-    pass
-
-
 def scalar_cls_from_name(name):
     if name == "geoarrow.wkb":
         return WkbScalar
     elif name == "geoarrow.wkt":
         return WktScalar
-    elif name == "geoarrow.point":
-        return PointScalar
-    elif name == "geoarrow.linestring":
-        return LinestringScalar
-    elif name == "geoarrow.polygon":
-        return PolygonScalar
-    elif name == "geoarrow.multipoint":
-        return MultiPointScalar
-    elif name == "geoarrow.multilinestring":
-        return MultiLinestringScalar
-    elif name == "geoarrow.multipolygon":
-        return MultiPolygonScalar
     else:
-        raise ValueError(f'Expected valid extension name but got "{name}"')
+        return GeometryExtensionScalar
 
 
 # Inject array_cls_from_name exactly once to avoid circular import

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
@@ -78,7 +78,8 @@ class BoxScalar(GeometryExtensionScalar):
     @property
     def bounds(self) -> dict:
         storage = self._array1().storage
-        return {k: v[0].as_py() for k, v in zip(storage.type.names, storage.flatten())}
+        fields = [storage.type.field(i) for i in range(storage.type.num_fields)]
+        return {k.name: v[0].as_py() for k, v in zip(fields, storage.flatten())}
 
     @property
     def xmin(self) -> float:

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pyarrow as pa
 import pyarrow_hotfix as _  # noqa: F401
 from geoarrow.pyarrow._kernel import Kernel
@@ -72,11 +74,55 @@ class WkbScalar(GeometryExtensionScalar):
         return self.value.as_py()
 
 
+class BoxScalar(GeometryExtensionScalar):
+    @property
+    def bounds(self) -> dict:
+        storage = self._array1().storage
+        return {k: v[0].as_py() for k, v in zip(storage.type.names, storage.flatten())}
+
+    @property
+    def xmin(self) -> float:
+        return self.bounds["xmin"]
+
+    @property
+    def ymin(self) -> float:
+        return self.bounds["ymin"]
+
+    @property
+    def xmax(self) -> float:
+        return self.bounds["xmax"]
+
+    @property
+    def ymax(self) -> float:
+        return self.bounds["ymax"]
+
+    @property
+    def zmin(self) -> Optional[float]:
+        return self.bounds["zmin"] if "zmin" in self.bounds else None
+
+    @property
+    def zmax(self) -> Optional[float]:
+        return self.bounds["zmax"] if "zmax" in self.bounds else None
+
+    @property
+    def mmin(self) -> Optional[float]:
+        return self.bounds["mmin"] if "mmin" in self.bounds else None
+
+    @property
+    def mmax(self) -> Optional[float]:
+        return self.bounds["mmax"] if "mmax" in self.bounds else None
+
+    def __repr__(self) -> str:
+        return f"BoxScalar({self.bounds})"
+
+
 def scalar_cls_from_name(name):
     if name == "geoarrow.wkb":
         return WkbScalar
     elif name == "geoarrow.wkt":
         return WktScalar
+    elif name == "geoarrow.box":
+        return BoxScalar
     else:
         return GeometryExtensionScalar
 

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/dataset.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/dataset.py
@@ -160,7 +160,7 @@ class GeoDataset:
         >>> table = pa.table([ga.array(["POINT (0.5 1.5)"])], ["geometry"])
         >>> dataset = gads.dataset(table)
         >>> dataset.index_fragments().to_pylist()
-        [{'_fragment_index': 0, 'geometry': {'xmin': 0.5, 'xmax': 0.5, 'ymin': 1.5, 'ymax': 1.5}}]
+        [{'_fragment_index': 0, 'geometry': {'xmin': 0.5, 'ymin': 1.5, 'xmax': 0.5, 'ymax': 1.5}}]
         """
         if self._index is None:
             self._index = self._build_index(

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/dataset.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/dataset.py
@@ -213,7 +213,7 @@ class GeoDataset:
 
         if isinstance(target, str):
             target = [target]
-        target_box = box_agg(target)
+        target_box = box_agg(target).as_py()
         maybe_intersects = GeoDataset._index_box_intersects(
             self.index_fragments(), target_box, self.geometry_columns
         )
@@ -255,7 +255,7 @@ class GeoDataset:
         kernel = Kernel.box_agg(type)
         for batch in reader:
             kernel.push(batch.column(0))
-        return kernel.finish()
+        return kernel.finish().storage
 
     @staticmethod
     def _index_fragments(fragments, columns, types, num_threads=None):
@@ -295,7 +295,7 @@ class GeoDataset:
 
     @staticmethod
     def _index_box_intersects(index, box, columns):
-        xmin, xmax, ymin, ymax = box.as_py().values()
+        xmin, ymin, xmax, ymax = box.values()
         expressions = []
         for col in columns:
             expr = (

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
@@ -508,7 +508,7 @@ _GEOPARQUET_GEOMETRY_TYPE_LABELS = [
     "MultiPoint",
     "MultiLineString",
     "MultiPolygon",
-    "GeometryCollection"
+    "GeometryCollection",
 ]
 
 _GEOPARQUET_DIMENSION_LABELS = [None, "", " Z", " M", " ZM"]

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
@@ -508,6 +508,7 @@ _GEOPARQUET_GEOMETRY_TYPE_LABELS = [
     "MultiPoint",
     "MultiLineString",
     "MultiPolygon",
+    "GeometryCollection"
 ]
 
 _GEOPARQUET_DIMENSION_LABELS = [None, "", " Z", " M", " ZM"]

--- a/geoarrow-pyarrow/tests/test_pyarrow.py
+++ b/geoarrow-pyarrow/tests/test_pyarrow.py
@@ -174,6 +174,20 @@ def test_scalar_geoarrow():
     assert repr(array[0]).startswith("GeometryExtensionScalar")
 
 
+def test_scalar_box():
+    # The box kernel doesn't yet implement non XY boxes
+    array = ga.box(["LINESTRING ZM (0 1 2 3, 4 5 6 7)"])
+    assert array[0].xmin == 0
+    assert array[0].ymin == 1
+    assert array[0].zmin is None
+    assert array[0].mmin is None
+    assert array[0].xmax == 4
+    assert array[0].ymax == 5
+    assert array[0].zmax is None
+    assert array[0].mmax is None
+    assert repr(array[0]).startswith("BoxScalar")
+
+
 def test_scalar_repr():
     array = ga.array(
         ["LINESTRING (100000 100000, 100000 100000, 100000 100000, 100000 100000)"]

--- a/geoarrow-pyarrow/tests/test_pyarrow.py
+++ b/geoarrow-pyarrow/tests/test_pyarrow.py
@@ -387,6 +387,24 @@ def test_multipolygon_array_from_geobuffers():
     assert ga.as_wkt(arr)[0].as_py() == "MULTIPOLYGON (((1 4, 2 5, 3 6, 1 4)))"
 
 
+def test_box_array_from_geobuffers():
+    arr = (
+        types.box()
+        .to_pyarrow()
+        .from_geobuffers(
+            b"\xff",
+            np.array([1.0, 2.0, 3.0]),
+            np.array([4.0, 5.0, 6.0]),
+            np.array([7.0, 8.0, 9.0]),
+            np.array([10.0, 11.0, 12.0]),
+        )
+    )
+    assert len(arr) == 3
+    assert arr[2].bounds == {"xmin": 3.0, "ymin": 6.0, "xmax": 9.0, "ymax": 12.0}
+    assert "BoxArray" in repr(arr)
+    assert "'xmin': 3.0" in repr(arr)
+
+
 # Easier to test here because we have actual geoarrow arrays to parse
 def test_c_array_view():
     arr = ga.as_geoarrow(["POLYGON ((0 0, 1 0, 0 1, 0 0))"])

--- a/geoarrow-pyarrow/tests/test_pyarrow.py
+++ b/geoarrow-pyarrow/tests/test_pyarrow.py
@@ -171,7 +171,7 @@ def test_scalar_geoarrow():
     array = ga.as_geoarrow(["POINT (0 1)"])
     assert array[0].wkt == "POINT (0 1)"
     assert array[0].wkb == ga.as_wkb(array).storage[0].as_py()
-    assert repr(array[0]).startswith("PointScalar")
+    assert repr(array[0]).startswith("GeometryExtensionScalar")
 
 
 def test_scalar_repr():
@@ -227,7 +227,7 @@ def test_kernel_as():
     out = kernel.push(array)
     assert out.type.extension_name == "geoarrow.point"
     assert out.type.crs.to_json_dict() == types.OGC_CRS84.to_json_dict()
-    assert isinstance(out, _array.PointArray)
+    assert isinstance(out, _array.GeometryExtensionArray)
 
 
 def test_kernel_format():

--- a/geoarrow-types/src/geoarrow/types/crs.py
+++ b/geoarrow-types/src/geoarrow/types/crs.py
@@ -133,7 +133,9 @@ class ProjJsonCrs(Crs):
 
 class StringCrs(Crs):
     def __init__(self, crs: Union[str, bytes]):
-        if isinstance(crs, bytes):
+        if isinstance(crs, str):
+            self._crs = crs
+        elif isinstance(crs, bytes):
             self._crs = crs.decode()
         else:
             self._crs = str(crs)

--- a/geoarrow-types/src/geoarrow/types/type_spec.py
+++ b/geoarrow-types/src/geoarrow/types/type_spec.py
@@ -272,7 +272,7 @@ class TypeSpec(NamedTuple):
             if "crs_type" in metadata and metadata["crs_type"] == "projjson":
                 out_crs = crs.ProjJsonCrs(metadata["crs"])
             else:
-                out_crs = crs.StringCrs(metadata["crs"])
+                out_crs = crs.create(metadata["crs"])
 
         return TypeSpec(edge_type=out_edges, crs=out_crs)
 


### PR DESCRIPTION
A future version of geoarrow-pyarrow will probably further reduce the dependency on geoarrow-c and/or mandate >- 0.2; however, for the time being this makes it easier for all the CI to hum happily along.