### PR TITLE
chore(geoarrow-pyarrow): Remove pyarrow_hotfix and set minimum version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          tags: true
+          fetch-tags: true
 
       - name: Check git setup
         run: |

--- a/geoarrow-pandas/src/geoarrow/pandas/lib.py
+++ b/geoarrow-pandas/src/geoarrow/pandas/lib.py
@@ -1,7 +1,6 @@
 import re as _re
 import pandas as _pd
 import pyarrow as _pa
-import pyarrow_hotfix as _  # noqa: F401
 import numpy as _np
 from geoarrow.types import TypeSpec, type_spec, Encoding
 import geoarrow.pyarrow as _ga

--- a/geoarrow-pyarrow/pyproject.toml
+++ b/geoarrow-pyarrow/pyproject.toml
@@ -23,7 +23,7 @@ description = ""
 authors = [{name = "Dewey Dunnington", email = "dewey@dunnington.ca"}]
 license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
-dependencies = ["pyarrow", "pyarrow_hotfix", "geoarrow-types"]
+dependencies = ["pyarrow >= 14.0.2", "geoarrow-types"]
 
 [project.optional-dependencies]
 test = ["pytest", "pandas", "numpy", "geopandas", "pyogrio", "pyproj", "geoarrow-c"]

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_array.py
@@ -1,5 +1,4 @@
 import pyarrow as pa
-import pyarrow_hotfix as _  # noqa: F401
 
 from geoarrow.pyarrow._kernel import Kernel, _geoarrow_c
 from geoarrow.pyarrow._type import (

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
@@ -1,6 +1,5 @@
 import pyarrow as pa
 import pyarrow.compute as pc
-import pyarrow_hotfix as _  # noqa: F401
 
 from geoarrow.types import (
     type_spec,

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_kernel.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_kernel.py
@@ -1,7 +1,6 @@
 import sys
 
 import pyarrow as pa
-import pyarrow_hotfix as _  # noqa: F401
 from geoarrow.types import box as box_spec
 from geoarrow.pyarrow._type import GeometryExtensionType
 

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_scalar.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 import pyarrow as pa
-import pyarrow_hotfix as _  # noqa: F401
 from geoarrow.pyarrow._kernel import Kernel
 from geoarrow.types.type_pyarrow import GeometryExtensionType
 

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_type.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_type.py
@@ -1,6 +1,5 @@
 from typing import Iterable
 import pyarrow as pa
-import pyarrow_hotfix as _  # noqa: F401
 
 from geoarrow import types
 from geoarrow.types.type_pyarrow import (

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/dataset.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/dataset.py
@@ -11,7 +11,6 @@ import pyarrow.compute as _compute
 import pyarrow.dataset as _ds
 import pyarrow.parquet as _pq
 import pyarrow.types as _types
-import pyarrow_hotfix as _  # noqa: F401
 from geoarrow.c.lib import CoordType
 from geoarrow.pyarrow._kernel import Kernel
 from geoarrow.pyarrow._type import GeometryExtensionType, wkb, wkt

--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/io.py
@@ -12,7 +12,6 @@ import geoarrow.pyarrow as _ga
 import pyarrow as _pa
 import pyarrow.parquet as _pq
 import pyarrow.types as _types
-import pyarrow_hotfix as _  # noqa: F401
 from geoarrow.pyarrow import _type
 from geoarrow.pyarrow import _compute
 


### PR DESCRIPTION
The hotfix will break in the forthcoming pyarrow attempting to unregister an extension type that no longer exists!