### PR TITLE
feat(geoarrow-types): Add support for GeoArrow 0.2 edge types

### DIFF
--- a/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
+++ b/geoarrow-pyarrow/src/geoarrow/pyarrow/_compute.py
@@ -423,8 +423,8 @@ def box_agg(obj):
     obj = obj_as_array_or_chunked(obj)
 
     # Spherical edges aren't supported by this algorithm
-    if obj.type.edge_type == EdgeType.SPHERICAL:
-        raise TypeError("Can't compute box of type with spherical edges")
+    if obj.type.edge_type != EdgeType.PLANAR:
+        raise TypeError("Can't compute box of type with non-planar edges")
 
     # Optimization: pyarrow's minmax kernel is fast and we can use it if we have struct
     # coords. So far, only a measurable improvement for points.

--- a/geoarrow-types/src/geoarrow/types/constants.py
+++ b/geoarrow-types/src/geoarrow/types/constants.py
@@ -243,6 +243,18 @@ class EdgeType(TypeSpecEnum):
     SPHERICAL = 2
     """Edges are geodesic on a sphere"""
 
+    VINCENTY = 3
+    """Edges are geodesic on a spheroid according to the Vincenty algorithm"""
+
+    THOMAS = 4
+    """Edges are geodesic on a spheroid according to the Thomas algorithm"""
+
+    ANDOYER = 5
+    """Edges are geodesic on a spheroid according to the Andoyer algorithm"""
+
+    KARNEY = 6
+    """Edges are geodesic on a spheroid according to the Karney algorithm"""
+
 
 _VALUE_COMMON_HELPER = {
     (Encoding.WKB, Encoding.LARGE_WKB): Encoding.LARGE_WKB,

--- a/geoarrow-types/src/geoarrow/types/type_spec.py
+++ b/geoarrow-types/src/geoarrow/types/type_spec.py
@@ -77,8 +77,8 @@ class TypeSpec(NamedTuple):
                 "edge_type or crs is unspecified"
             )
 
-        if self.edge_type == EdgeType.SPHERICAL:
-            metadata["edges"] = "spherical"
+        if self.edge_type != EdgeType.PLANAR:
+            metadata["edges"] = self.edge_type.name.lower()
 
         if self.crs is None:
             pass

--- a/geoarrow-types/tests/test_type_spec.py
+++ b/geoarrow-types/tests/test_type_spec.py
@@ -50,6 +50,10 @@ def test_type_spec_extension_metadata():
         == '{"edges": "spherical"}'
     )
     assert (
+        TypeSpec(edge_type=EdgeType.VINCENTY).with_defaults().extension_metadata()
+        == '{"edges": "vincenty"}'
+    )
+    assert (
         TypeSpec(crs=gt.OGC_CRS84)
         .with_defaults()
         .extension_metadata()


### PR DESCRIPTION
Adds support for other edge types to the Python bindings