### PR TITLE
chore(geoarrow-pyarrow): Constrain geoarrow-c dependency to latest version

### DIFF
--- a/geoarrow-pyarrow/pyproject.toml
+++ b/geoarrow-pyarrow/pyproject.toml
@@ -23,7 +23,7 @@ description = ""
 authors = [{name = "Dewey Dunnington", email = "dewey@dunnington.ca"}]
 license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
-dependencies = ["pyarrow >= 14.0.2", "geoarrow-types", "geoarrow-c"]
+dependencies = ["pyarrow >= 14.0.2", "geoarrow-types", "geoarrow-c >= 0.3.0"]
 
 [project.optional-dependencies]
 test = ["pytest", "pandas", "numpy", "geopandas", "pyogrio", "pyproj"]


### PR DESCRIPTION
An earlier PR made this optional...we can still do that, but there was some downstream usage that relies on the kernels being there and I'm hoping to minimize the disruption of this particular change.