### PR TITLE
fix(geoarrow-pyarrow): Fix roundtrip to C and back for WkbView array

### DIFF
--- a/geoarrow-pyarrow/tests/test_pyarrow.py
+++ b/geoarrow-pyarrow/tests/test_pyarrow.py
@@ -150,6 +150,10 @@ def test_array_view_types():
     assert array.type == ga.wkb_view()
     assert array.type.storage_type == pa.binary_view()
 
+    schema_capsule, array_capsule = array.__arrow_c_array__()
+    rearr = pa.Array._import_from_c_capsule(schema_capsule, array_capsule)
+    rearr.validate(full=True)
+
 
 def test_array_repr():
     array = ga.array(["POINT (30 10)"])


### PR DESCRIPTION
I'm not sure exactly where the issue is here but I suspect it's in geoarrow-pyarrow somewhere given that I was unable to replicate without geoarrow-pyarrow:

```python
import pyarrow as pa
import json

class WkbType(pa.ExtensionType):
    """Minimal geoarrow.wkb implementation"""

    def __init__(self, crs=None, edges=None, *, storage_type=pa.binary(), **kwargs):
        self.crs = crs
        self.edges = edges
        super().__init__(storage_type, "geoarrow.wkb")

    def __arrow_ext_serialize__(self):
        obj = {"crs": self.crs, "edges": self.edges}
        return json.dumps({k: v for k, v in obj.items() if v}).encode()

    @classmethod
    def __arrow_ext_deserialize__(cls, storage_type, serialized):
        obj: dict = json.loads(serialized)
        return WkbType(**obj, storage_type=storage_type)
    
pa.register_extension_type(WkbType())


wkbs = WkbType(storage_type=pa.binary_view()).wrap_array(pa.array([b"abcdefghijkl"], pa.binary_view()))
wkbs.validate(full=True)

schema_capsule, array_capsule = wkbs.__arrow_c_array__()
pa.Array._import_from_c_capsule(schema_capsule, array_capsule).validate(full=True)
```